### PR TITLE
Fix for picture mode changes not following through.

### DIFF
--- a/tools/check_lg_picture_mode_regression.pl
+++ b/tools/check_lg_picture_mode_regression.pl
@@ -1,0 +1,81 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use Test::More;
+
+my $path='usr/sbin/pgenerator-lg';
+open(my $fh,'<',$path) or die "open $path: $!";
+local $/;
+my $source=<$fh>;
+close($fh);
+
+my ($payload_sub)=$source=~/(sub lg_picture_mode_ssap_payload \(\@\) \{.*?^\})/ms;
+ok($payload_sub,'picture-mode SSAP payload helper is present');
+{
+ package LGPictureModePayloadTest;
+ no strict 'refs';
+ eval "$payload_sub\n1;" or die $@;
+}
+
+is_deeply(
+ LGPictureModePayloadTest::lg_picture_mode_ssap_payload('filmMaker'),
+ {
+  category => 'picture',
+  settings => { pictureMode => 'filmMaker' },
+ },
+ 'picture-mode selection uses the minimal public WebOS settings payload',
+);
+
+my @matching_subs;
+for my $name (qw(
+ map_picture_mode_label_to_ddc_name
+ lg_picture_mode_signal_for_canonical_name
+ lg_picture_mode_signal_compatible
+ lg_picture_mode_readback_matches
+)) {
+ my ($sub)=$source=~/(sub \Q$name\E \(\@\) \{.*?^\})/ms;
+ ok($sub,"$name is present");
+ push(@matching_subs,$sub||'');
+}
+{
+ package LGPictureModeReadbackTest;
+ no strict 'refs';
+ eval join("\n",@matching_subs)."\n1;" or die $@;
+}
+ok(
+ LGPictureModeReadbackTest::lg_picture_mode_readback_matches('filmMaker','filmMaker','sdr'),
+ 'matching SDR picture-mode readback is accepted',
+);
+ok(
+ LGPictureModeReadbackTest::lg_picture_mode_readback_matches('dolbyHdrCinema','dolbyHdrCinemaDark','dv'),
+ 'equivalent Dolby Vision write and readback names are accepted',
+);
+ok(
+ !LGPictureModeReadbackTest::lg_picture_mode_readback_matches('filmMaker','cinema','sdr'),
+ 'stale picture-mode readback is rejected',
+);
+
+my ($workflow)=$source=~/(sub lg_picture_set_workflow \(\@\) \{.*?^\})/ms;
+ok($workflow,'picture-set workflow is present');
+like(
+ $workflow,
+ qr/"settings\/setSystemSettings",\s*\$set_payload/s,
+ 'picture-mode write uses public SSAP setSystemSettings',
+);
+unlike(
+ $workflow,
+ qr/set_picture_mode_active_app|current_app.*picture_mode_only/s,
+ 'picture-mode write is not diverted through a scoped Luna alert',
+);
+like(
+ $workflow,
+ qr/get_picture_mode_after_.*?settings\/getSystemSettings/s,
+ 'picture-mode selection performs an independent readback',
+);
+like(
+ $workflow,
+ qr/picture-mode-readback-mismatch/,
+ 'missing or stale picture-mode readback is reported as failure',
+);
+
+done_testing();

--- a/tools/check_lg_picture_mode_regression.pl
+++ b/tools/check_lg_picture_mode_regression.pl
@@ -1,19 +1,29 @@
 #!/usr/bin/env perl
 use strict;
 use warnings;
+use FindBin;
 use Test::More;
 
-my $path='usr/sbin/pgenerator-lg';
+my $path="$FindBin::Bin/../usr/sbin/pgenerator-lg";
 open(my $fh,'<',$path) or die "open $path: $!";
-local $/;
-my $source=<$fh>;
+my $source=do { local $/; <$fh> };
 close($fh);
 
-my ($payload_sub)=$source=~/(sub lg_picture_mode_ssap_payload \(\@\) \{.*?^\})/ms;
-ok($payload_sub,'picture-mode SSAP payload helper is present');
+# Extraction relies on the file's convention that only a sub's own closing
+# brace sits in column 0. BAIL_OUT on a miss so a failed extraction reads as
+# "the source changed shape", not as a confusing runtime die further down.
+sub extract_sub {
+ my $name=shift;
+ my ($sub)=$source=~/(sub \Q$name\E \(\@\) \{.*?^\})/ms;
+ ok($sub,"$name is present") or BAIL_OUT("could not extract sub $name from $path");
+ return $sub;
+}
+
+# --- lg_picture_mode_ssap_payload -------------------------------------------
+
 {
+ my $payload_sub=extract_sub('lg_picture_mode_ssap_payload');
  package LGPictureModePayloadTest;
- no strict 'refs';
  eval "$payload_sub\n1;" or die $@;
 }
 
@@ -25,38 +35,67 @@ is_deeply(
  },
  'picture-mode selection uses the minimal public WebOS settings payload',
 );
+is_deeply(
+ LGPictureModePayloadTest::lg_picture_mode_ssap_payload(undef),
+ {
+  category => 'picture',
+  settings => { pictureMode => '' },
+ },
+ 'an undefined picture mode degrades to an empty payload value instead of dying',
+);
 
-my @matching_subs;
-for my $name (qw(
- map_picture_mode_label_to_ddc_name
- lg_picture_mode_signal_for_canonical_name
- lg_picture_mode_signal_compatible
- lg_picture_mode_readback_matches
-)) {
- my ($sub)=$source=~/(sub \Q$name\E \(\@\) \{.*?^\})/ms;
- ok($sub,"$name is present");
- push(@matching_subs,$sub||'');
-}
+# --- lg_picture_mode_readback_matches ---------------------------------------
+
 {
+ my $code=join("\n",
+  extract_sub('lg_picture_mode_readback_canonical'),
+  extract_sub('lg_picture_mode_readback_matches'));
  package LGPictureModeReadbackTest;
- no strict 'refs';
- eval join("\n",@matching_subs)."\n1;" or die $@;
+ eval "$code\n1;" or die $@;
 }
-ok(
- LGPictureModeReadbackTest::lg_picture_mode_readback_matches('filmMaker','filmMaker','sdr'),
- 'matching SDR picture-mode readback is accepted',
-);
-ok(
- LGPictureModeReadbackTest::lg_picture_mode_readback_matches('dolbyHdrCinema','dolbyHdrCinemaDark','dv'),
- 'equivalent Dolby Vision write and readback names are accepted',
-);
-ok(
- !LGPictureModeReadbackTest::lg_picture_mode_readback_matches('filmMaker','cinema','sdr'),
- 'stale picture-mode readback is rejected',
-);
 
-my ($workflow)=$source=~/(sub lg_picture_set_workflow \(\@\) \{.*?^\})/ms;
-ok($workflow,'picture-set workflow is present');
+sub readback_matches { return LGPictureModeReadbackTest::lg_picture_mode_readback_matches(@_); }
+
+ok(readback_matches('filmMaker','filmMaker'),
+ 'matching picture-mode readback is accepted');
+ok(!readback_matches('filmMaker','cinema'),
+ 'stale picture-mode readback is rejected');
+ok(readback_matches('dolbyHdrCinema','dolbyHdrCinemaDark'),
+ 'the C2 Dolby Vision readback-only label matches its write value');
+ok(readback_matches('dolbyHdrCinemaDark','dolbyHdrCinema'),
+ 'Dolby Vision readback equivalence holds in both directions');
+ok(!readback_matches('dolbyHdrCinema','dolbyHdrCinemaBright'),
+ 'Dolby Vision Cinema and Cinema Bright remain distinct');
+ok(readback_matches('game','gameOptimizer'),
+ 'the Game Optimizer readback label matches the game enum');
+ok(!readback_matches('standard','aps'),
+ 'Energy Saving (aps) readback does not verify a standard request');
+ok(!readback_matches('standard','eco'),
+ 'Eco readback does not verify a standard request');
+ok(!readback_matches('vivid','sports'),
+ 'Sports readback does not verify a vivid request');
+ok(!readback_matches('cinema','cinemaHome'),
+ 'Cinema Home readback does not verify a cinema request');
+ok(readback_matches('FILMMAKER','filmMaker'),
+ 'case differences in enum names are tolerated');
+ok(readback_matches('hdrFilmMaker','hdr_filmmaker'),
+ 'separator differences in enum names are tolerated');
+ok(!readback_matches('hdrCinema','hdrStandard'),
+ 'different HDR modes are rejected');
+ok(readback_matches('unknownMode','unknownMode'),
+ 'identical unmapped mode names still verify');
+ok(!readback_matches('unknownModeA','unknownModeB'),
+ 'different unmapped mode names are rejected');
+ok(!readback_matches('filmMaker',''),
+ 'an empty readback value is never treated as verified');
+ok(!readback_matches('filmMaker',undef),
+ 'an undefined readback value is never treated as verified');
+ok(!readback_matches('','cinema'),
+ 'an empty requested mode is never treated as verified');
+
+# --- lg_picture_set_workflow: source-shape checks ---------------------------
+
+my $workflow=extract_sub('lg_picture_set_workflow');
 like(
  $workflow,
  qr/"settings\/setSystemSettings",\s*\$set_payload/s,
@@ -64,18 +103,170 @@ like(
 );
 unlike(
  $workflow,
- qr/set_picture_mode_active_app|current_app.*picture_mode_only/s,
- 'picture-mode write is not diverted through a scoped Luna alert',
+ qr/set_picture_mode_active_app/,
+ 'the current_app-scoped Luna alert write path is not reintroduced',
+);
+like(
+ $workflow,
+ qr/push\(\@\{\$readback_keys\},"pictureMode"\)/,
+ 'picture-mode-only requests always gain a pictureMode readback key',
 );
 like(
  $workflow,
  qr/get_picture_mode_after_.*?settings\/getSystemSettings/s,
- 'picture-mode selection performs an independent readback',
+ 'picture-mode selection performs a separate readback poll',
 );
 like(
  $workflow,
- qr/picture-mode-readback-mismatch/,
- 'missing or stale picture-mode readback is reported as failure',
+ qr/if\(&lg_picture_mode_readback_matches\(\$active_picture_mode,\$observed_picture_mode\)\)/,
+ 'the poll verifies the observed mode through the readback matcher',
 );
+like(
+ $workflow,
+ qr/if\(\$picture_mode_only && !\$picture_mode_readback_verified\) \{.*?picture-mode-readback-mismatch/s,
+ 'an unverified picture-mode readback is reported as failure',
+);
+
+# --- lg_picture_set_workflow: behavioural harness ---------------------------
+# Run the real workflow sub with the real mapper/matcher and stubbed TV I/O.
+# The stubs mirror the response shapes of the real helpers (json_ok,
+# json_error, response_is_app_failure) closely enough to drive every branch
+# under test without a TV.
+
+{
+ my $helpers=join("\n",map { extract_sub($_) } qw(
+  map_picture_mode_label_to_ddc_name
+  lg_picture_mode_signal_for_canonical_name
+  lg_picture_mode_signal_compatible
+  lg_picture_mode_signal_examples
+  lg_picture_mode_ssap_payload
+  lg_picture_mode_readback_canonical
+  lg_picture_mode_readback_matches
+ ));
+ my $stubs=<<'STUBS';
+our (@READBACK_MODES,@REQUEST_LABELS,@LUNA_LABELS,$SET_RESPONSE,$LUNA_RESPONSE);
+$WRITABLE_PICTURE_MODES_RE=qr/^(?:expert|cinema|filmmaker|game|standard)/;
+sub lg_authenticated_session { return { status => "ok", session => {}, client_key => "test-key", hello_info => {}, system_info => {}, software_info => {} }; }
+sub lg_generation_info { return {}; }
+sub lg_ddc_has_22pt_rgb { return 0; }
+sub lg_picture_mode_for_calibration { return ""; }
+sub lg_ddc_1d_target_info { return {}; }
+sub lg_ddc_1d_nonzero_map { return {}; }
+sub diag_log_append { return; }
+sub websocket_close { return; }
+sub json_true { return 1; }
+sub json_false { return 0; }
+sub json_bool { return $_[0] ? 1 : 0; }
+sub json_error {
+ my ($message,$extra)=@_;
+ $extra={} if(ref($extra) ne "HASH");
+ $extra->{"status"}="error";
+ $extra->{"message"}=$message;
+ return $extra;
+}
+sub json_ok {
+ my $extra=shift;
+ $extra={} if(ref($extra) ne "HASH");
+ $extra->{"status"}="ok";
+ return $extra;
+}
+sub json_permission_error {
+ my ($message,$extra)=@_;
+ $extra=&json_error($message,$extra);
+ $extra->{"error_code"}="insufficient-permissions";
+ return $extra;
+}
+sub response_is_app_failure {
+ my $response=shift;
+ return (0,"") if(ref($response) ne "HASH");
+ return (1,$response->{"error"}||"error envelope") if(($response->{"type"}||"") eq "error");
+ my $payload=(ref($response->{"payload"}) eq "HASH") ? $response->{"payload"} : {};
+ return (1,"returnValue false") if(defined($payload->{"returnValue"}) && !$payload->{"returnValue"});
+ return (0,"");
+}
+sub lg_request {
+ my ($session,$label,$path,$payload,$timeout)=@_;
+ push(@REQUEST_LABELS,$label);
+ return $SET_RESPONSE if($label eq "set_picture_mode");
+ if($label =~ /^get_picture_mode_after_/) {
+  return undef if(!@READBACK_MODES);
+  my $mode=shift(@READBACK_MODES);
+  return { type => "response", payload => { returnValue => 1, settings => { pictureMode => $mode } } };
+ }
+ return { type => "response", payload => { returnValue => 1, settings => {} } };
+}
+sub lg_luna_request {
+ my ($session,$label,$path,$payload,$timeout)=@_;
+ push(@LUNA_LABELS,$label);
+ return $LUNA_RESPONSE;
+}
+STUBS
+ package LGWorkflowRunTest;
+ eval "no strict;\nno warnings;\n$stubs\n$helpers\n$workflow\n1;" or die $@;
+}
+
+sub run_picture_mode_workflow {
+ my (%opt)=@_;
+ @LGWorkflowRunTest::READBACK_MODES=@{$opt{readback_modes}||[]};
+ @LGWorkflowRunTest::REQUEST_LABELS=();
+ @LGWorkflowRunTest::LUNA_LABELS=();
+ $LGWorkflowRunTest::SET_RESPONSE=$opt{set_response}
+  || { type => "response", payload => { returnValue => 1 } };
+ $LGWorkflowRunTest::LUNA_RESPONSE=$opt{luna_response}
+  || { type => "response", payload => { returnValue => 1 } };
+ return LGWorkflowRunTest::lg_picture_set_workflow(
+  "192.0.2.10","test-key",1,
+  { pictureMode => $opt{request_mode} },
+  [],"hdmi2",0,"",0,0,0,0,$opt{signal_mode}||"sdr");
+}
+
+# Scenario 1: readback matches on the first poll attempt.
+{
+ my $result=run_picture_mode_workflow(request_mode => "filmMaker", readback_modes => ["filmMaker"]);
+ is($result->{status},'ok','verified first readback reports success');
+ ok($result->{picture_mode_readback_verified},'success payload marks the readback verified');
+ is($result->{picture_mode_readback_attempts},1,'success payload counts one readback attempt');
+ is($result->{picture_settings}{pictureMode},'filmMaker','success payload carries the observed mode');
+ is(scalar(grep { $_ eq 'set_picture_mode' } @LGWorkflowRunTest::REQUEST_LABELS),1,
+  'exactly one SSAP picture-mode write was sent');
+}
+
+# Scenario 2: TV needs several polls before the mode lands.
+{
+ my $result=run_picture_mode_workflow(request_mode => "filmMaker",
+  readback_modes => ["cinema","cinema","cinema","filmMaker"]);
+ is($result->{status},'ok','late-arriving readback still reports success');
+ is($result->{picture_mode_readback_attempts},4,'poll kept reading until the mode was observed');
+}
+
+# Scenario 3: TV acknowledges the write but stays on the previous mode.
+{
+ my $result=run_picture_mode_workflow(request_mode => "filmMaker",
+  readback_modes => [("cinema") x 10]);
+ is($result->{status},'error','stale readback reports failure, not success');
+ is($result->{error_code},'picture-mode-readback-mismatch','stale readback carries the mismatch error code');
+ is($result->{observed_picture_mode},'cinema','the mode the TV actually reported is surfaced');
+ like($result->{message},qr/remained on 'cinema'/,'failure message names the stale mode');
+}
+
+# Scenario 4: TV never returns a usable readback at all.
+{
+ my $result=run_picture_mode_workflow(request_mode => "filmMaker", readback_modes => []);
+ is($result->{status},'error','missing readback reports failure, not success');
+ is($result->{error_code},'picture-mode-readback-mismatch','missing readback carries the mismatch error code');
+ is($result->{observed_picture_mode},'','no observed mode is reported when the TV never answered');
+}
+
+# Scenario 5: SSAP write is refused for permissions; the Luna fallback applies
+# the mode and the readback poll still decides success.
+{
+ my $result=run_picture_mode_workflow(request_mode => "filmMaker",
+  set_response => { type => "error", error => "401 insufficient permissions" },
+  readback_modes => ["filmMaker"]);
+ is($result->{status},'ok','permission-refused SSAP write recovers through the Luna fallback');
+ ok($result->{picture_mode_readback_verified},'the Luna fallback result is still readback-verified');
+ is(scalar(grep { $_ eq 'set_picture_settings_luna' } @LGWorkflowRunTest::LUNA_LABELS),1,
+  'the Luna fallback write path was used exactly once');
+}
 
 done_testing();

--- a/usr/sbin/pgenerator-lg
+++ b/usr/sbin/pgenerator-lg
@@ -225,6 +225,30 @@ sub lg_picture_mode_signal_examples (@) {
  return ();
 }
 
+# Picture-mode selection is a public WebOS settings write. Keep this payload
+# deliberately minimal: current_app and input dimensions target stored setting
+# scopes rather than proving that the foreground HDMI picture-mode bank moved.
+sub lg_picture_mode_ssap_payload (@) {
+ my $picture_mode=shift;
+ $picture_mode="" if(!defined($picture_mode));
+ return {
+  category => "picture",
+  settings => { pictureMode => $picture_mode },
+ };
+}
+
+sub lg_picture_mode_readback_matches (@) {
+ my ($requested,$observed,$signal_mode)=@_;
+ $requested="" if(!defined($requested));
+ $observed="" if(!defined($observed));
+ return 0 if($requested eq "" || $observed eq "");
+ my $requested_mode=&map_picture_mode_label_to_ddc_name($requested,$signal_mode);
+ my $observed_mode=&map_picture_mode_label_to_ddc_name($observed,$signal_mode);
+ $requested_mode=$requested if($requested_mode eq "");
+ $observed_mode=$observed if($observed_mode eq "");
+ return ($requested_mode eq $observed_mode) ? 1 : 0;
+}
+
 
 $WS_GUID="258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
 $REQUEST_ENV="PGEN_LG_REQUEST_B64";
@@ -5375,6 +5399,9 @@ sub lg_picture_set_workflow (@) {
  $settings->{"pictureMode"}=$mapped_caller_picture_mode if($mapped_caller_picture_mode ne "");
  $caller_picture_mode=$mapped_caller_picture_mode;
  my $picture_mode_only=($caller_picture_mode ne "" && scalar(keys(%{$settings}))==1) ? 1 : 0;
+ if($picture_mode_only && !grep { $_ eq "pictureMode" } @{$readback_keys}) {
+  push(@{$readback_keys},"pictureMode");
+ }
  my $active_picture_mode=$caller_picture_mode || $fallback_picture_mode;
  if($picture_mode_only && $generation->{"ddc_only_white_balance"}) {
   my $picture_settings=&lg_ddc_virtual_picture_settings($ip,$active_picture_mode);
@@ -5451,22 +5478,12 @@ sub lg_picture_set_workflow (@) {
   };
  }
 
- my $set_payload={
+ my $set_payload=$picture_mode_only
+  ? &lg_picture_mode_ssap_payload($active_picture_mode)
+  : {
 	  category => "picture",
 	  settings => $settings_to_apply,
 	 };
- if($picture_mode_only) {
-  # Bind the Luna write to the foreground HDMI application. A bare
-  # pictureMode database write changes the reported preset but can leave the
-  # active Dolby Vision video pipeline detached on the C2. current_app alone
-  # is insufficient there; the input dimension identifies the live pipeline
-  # that must perform the mode transition.
-  $set_payload->{"current_app"}=&json_true();
-  $set_payload->{"dimension"}={
-   input => $tv_input,
-   "_3dStatus" => "2d",
-  } if($tv_input ne "");
- }
  my $panel_light_category=($panel_light_only && $tv_input ne "" && $active_picture_mode ne "") ? "picture\$".$tv_input.".".$active_picture_mode.".2d.x" : "";
  $set_payload->{"dimension"}={ pictureMode => $active_picture_mode } if($active_picture_mode ne "" && !$picture_mode_only && !$panel_light_only);
 
@@ -5582,13 +5599,15 @@ sub lg_picture_set_workflow (@) {
   return &json_error($ddc_message,$extra);
  }
 
- # Picture-mode transitions must use the internal Luna settings service.
- # The public SSAP route can update/read back pictureMode without making the
- # corresponding active HDMI pipeline transition on some Dolby Vision modes.
- # Other picture controls continue to use the normal SSAP route.
- my $response=$picture_mode_only
-  ? &lg_luna_request($session,"set_picture_mode_active_app","com.webos.settingsservice/setSystemSettings",$set_payload,$connect_timeout + 2)
-  : &lg_request($session,"set_picture_settings","settings/setSystemSettings",$set_payload,$connect_timeout + 2);
+ # Use the same public SSAP picture-mode command as LG's settings clients:
+ # write the mode alone, then prove the foreground bank with a separate read.
+ my $response=&lg_request(
+  $session,
+  $picture_mode_only ? "set_picture_mode" : "set_picture_settings",
+  "settings/setSystemSettings",
+  $set_payload,
+  $connect_timeout + 2
+ );
  if(ref($response) ne "HASH") {
   &websocket_close($session);
   &diag_log_append("picture_set:no-response",{ ip => $ip, picture_mode => $active_picture_mode });
@@ -5783,6 +5802,9 @@ sub lg_picture_set_workflow (@) {
   }
  }
 	 my $settings_after={};
+	 my $picture_mode_readback_verified=0;
+	 my $picture_mode_readback_attempts=0;
+	 my $observed_picture_mode="";
 	  if(@{$readback_keys}) {
 	  if($panel_light_only) {
 	   my @readback_payloads=();
@@ -5825,6 +5847,29 @@ sub lg_picture_set_workflow (@) {
 	    last if(%{$settings_after} && $verified);
 	    select(undef,undef,undef,0.4) if($read_attempt<13);
 	   }
+	  } elsif($picture_mode_only) {
+	   # An accepted setSystemSettings response is not proof: WebOS may accept
+	   # the write while leaving the selected input on its previous bank. Poll
+	   # the same public settings plane used by the proven client until the TV
+	   # independently reports the requested mode.
+	   for(my $read_attempt=0;$read_attempt<10;$read_attempt++) {
+	    $picture_mode_readback_attempts=$read_attempt + 1;
+	    my $followup=&lg_request($session,"get_picture_mode_after_${read_attempt}","settings/getSystemSettings",{
+	     category => "picture",
+	     keys => ["pictureMode"],
+	    },$connect_timeout + 2);
+	    if(ref($followup) eq "HASH" && ($followup->{"type"}||"") ne "error"
+	       && ref($followup->{"payload"}) eq "HASH"
+	       && ref($followup->{"payload"}{"settings"}) eq "HASH") {
+	     $observed_picture_mode=$followup->{"payload"}{"settings"}{"pictureMode"}||"";
+	     $settings_after=$followup->{"payload"}{"settings"};
+	     if(&lg_picture_mode_readback_matches($active_picture_mode,$observed_picture_mode,$signal_mode)) {
+	      $picture_mode_readback_verified=1;
+	      last;
+	     }
+	    }
+	    select(undef,undef,undef,0.35) if($read_attempt<9);
+	   }
 	  } else {
 	   my $readback_category="picture";
 		   if(!$native_white_balance && !$picture_mode_only && $tv_input ne "" && $active_picture_mode ne "") {
@@ -5841,7 +5886,29 @@ sub lg_picture_set_workflow (@) {
 	   }
 	  }
 		 }
-	 if($panel_light_only && !%{$settings_after}) {
+	 if($picture_mode_only && !$picture_mode_readback_verified) {
+	  &websocket_close($session);
+	  &diag_log_append("picture_set:mode-readback-mismatch",{
+	   ip => $ip,
+	   requested_picture_mode => $active_picture_mode,
+	   observed_picture_mode => $observed_picture_mode,
+	   readback_attempts => $picture_mode_readback_attempts,
+	   response => $response,
+	  });
+	  my $message=$observed_picture_mode ne ""
+	   ? "LG TV acknowledged the picture-mode request for '$active_picture_mode' but remained on '$observed_picture_mode'."
+	   : "LG TV acknowledged the picture-mode request for '$active_picture_mode' but did not return a verified picture-mode readback.";
+	  return &json_error($message,{
+	   ip => $ip,
+	   active_picture_mode => $active_picture_mode,
+	   requested_picture_mode => $active_picture_mode,
+	   observed_picture_mode => $observed_picture_mode,
+	   picture_mode_readback_attempts => $picture_mode_readback_attempts,
+	   picture_mode_write_path => "ssap://settings/setSystemSettings",
+	   error_code => "picture-mode-readback-mismatch",
+	   raw_response => $response,
+	  });
+	 } elsif($panel_light_only && !%{$settings_after}) {
 	  &websocket_close($session);
 	  return &json_error("LG TV acknowledged the panel-light write but did not return a verified readback.",{
 	   ip => $ip,
@@ -5854,13 +5921,23 @@ sub lg_picture_set_workflow (@) {
   $settings_after->{"pictureMode"}=$active_picture_mode if($active_picture_mode ne "");
  }
  &websocket_close($session);
- &diag_log_append("picture_set:ok",{ ip => $ip, picture_mode => $active_picture_mode, applied => $settings_to_apply, settings_after => $settings_after });
+ &diag_log_append("picture_set:ok",{
+  ip => $ip,
+  picture_mode => $active_picture_mode,
+  applied => $settings_to_apply,
+  settings_after => $settings_after,
+  picture_mode_readback_verified => &json_bool($picture_mode_readback_verified),
+  picture_mode_readback_attempts => $picture_mode_readback_attempts,
+ });
  return &json_ok({
   ip => $ip,
   client_key => $auth->{"client_key"},
   picture_settings => $settings_after,
   applied => $settings_to_apply,
   active_picture_mode => $active_picture_mode,
+	  picture_mode_readback_verified => &json_bool($picture_mode_readback_verified),
+	  picture_mode_readback_attempts => $picture_mode_readback_attempts,
+	  picture_mode_write_path => $picture_mode_only ? "ssap://settings/setSystemSettings" : "",
 	  calibration_mode => &json_bool($keep_calibration_mode && $ddc_white_balance_only),
   hello_info => $auth->{"hello_info"},
   system_info => $auth->{"system_info"},

--- a/usr/sbin/pgenerator-lg
+++ b/usr/sbin/pgenerator-lg
@@ -226,8 +226,12 @@ sub lg_picture_mode_signal_examples (@) {
 }
 
 # Picture-mode selection is a public WebOS settings write. Keep this payload
-# deliberately minimal: current_app and input dimensions target stored setting
-# scopes rather than proving that the foreground HDMI picture-mode bank moved.
+# deliberately minimal. Earlier builds routed mode-only writes through an
+# alert-backed Luna call scoped with current_app and the CEC-derived input
+# dimension; on a G3 (OLED55G36LA, SDR, PR #1) that route acknowledged the
+# write without moving the foreground HDMI picture-mode bank. Verification
+# now lives in lg_picture_set_workflow's readback poll, not in payload
+# scoping.
 sub lg_picture_mode_ssap_payload (@) {
  my $picture_mode=shift;
  $picture_mode="" if(!defined($picture_mode));
@@ -237,15 +241,34 @@ sub lg_picture_mode_ssap_payload (@) {
  };
 }
 
+# Readback verification must NOT reuse map_picture_mode_label_to_ddc_name:
+# that table is an input-alias map which deliberately collapses distinct
+# WebOS modes onto convenient write values (aps/eco => standard, sports =>
+# vivid, cinemaHome => cinema). Folding the TV's reply through it would
+# verify a "standard" request while the TV sits in Energy Saving -- exactly
+# the false success the readback exists to catch. Compare case- and
+# separator-normalized enum names instead, plus the few labels WebOS reports
+# for a mode it only accepts under a different write value.
+sub lg_picture_mode_readback_canonical (@) {
+ my $name=shift;
+ $name="" if(!defined($name));
+ $name=lc($name);
+ $name=~s/[\s_\-]+//g;
+ my %readback_synonym=(
+  # C2 webOS 4.1.0: writing "dolbyHdrCinema" reads back "dolbyHdrCinemaDark"
+  # (see the dolbyHdrCinema notes in map_picture_mode_label_to_ddc_name).
+  "dolbyhdrcinemadark" => "dolbyhdrcinema",
+  # Newer generations report the game enum under its Game Optimizer name.
+  "gameoptimizer" => "game",
+ );
+ return $readback_synonym{$name}||$name;
+}
+
 sub lg_picture_mode_readback_matches (@) {
- my ($requested,$observed,$signal_mode)=@_;
- $requested="" if(!defined($requested));
- $observed="" if(!defined($observed));
- return 0 if($requested eq "" || $observed eq "");
- my $requested_mode=&map_picture_mode_label_to_ddc_name($requested,$signal_mode);
- my $observed_mode=&map_picture_mode_label_to_ddc_name($observed,$signal_mode);
- $requested_mode=$requested if($requested_mode eq "");
- $observed_mode=$observed if($observed_mode eq "");
+ my ($requested,$observed)=@_;
+ my $requested_mode=&lg_picture_mode_readback_canonical($requested);
+ my $observed_mode=&lg_picture_mode_readback_canonical($observed);
+ return 0 if($requested_mode eq "" || $observed_mode eq "");
  return ($requested_mode eq $observed_mode) ? 1 : 0;
 }
 
@@ -5400,6 +5423,9 @@ sub lg_picture_set_workflow (@) {
  $caller_picture_mode=$mapped_caller_picture_mode;
  my $picture_mode_only=($caller_picture_mode ne "" && scalar(keys(%{$settings}))==1) ? 1 : 0;
  if($picture_mode_only && !grep { $_ eq "pictureMode" } @{$readback_keys}) {
+  # Verification is mandatory for mode-only writes: the readback poll below
+  # is the success criterion, so a caller's skip_readback (which arrives here
+  # as an empty readback_keys list) is deliberately overridden.
   push(@{$readback_keys},"pictureMode");
  }
  my $active_picture_mode=$caller_picture_mode || $fallback_picture_mode;
@@ -5599,8 +5625,8 @@ sub lg_picture_set_workflow (@) {
   return &json_error($ddc_message,$extra);
  }
 
- # Use the same public SSAP picture-mode command as LG's settings clients:
- # write the mode alone, then prove the foreground bank with a separate read.
+ # Write the mode alone over public SSAP setSystemSettings, then verify with
+ # the separate getSystemSettings poll below (see that block's caveats).
  my $response=&lg_request(
   $session,
   $picture_mode_only ? "set_picture_mode" : "set_picture_settings",
@@ -5763,9 +5789,14 @@ sub lg_picture_set_workflow (@) {
 	    &diag_log_append($fallback->{"fail_label"},{ ip => $ip, picture_mode => $active_picture_mode, tv_input => $tv_input, category => $category, response => $fallback_response, message => $fallback_message });
 	   }
 	  }
-  if($failed && !$picture_mode_only && !$panel_light_only && ($failure_message =~ /401\s+insufficient permissions/i || $failure_message =~ /insufficient permissions/i)) {
+  # Mode-only writes may also land here on client keys without SSAP settings
+  # write permission. The Luna fallback is safe for them because the readback
+  # poll below still decides success independently of the write
+  # acknowledgement -- and they keep the minimal payload, since scoping the
+  # write to the target mode's own settings bank cannot switch modes.
+  if($failed && !$panel_light_only && ($failure_message =~ /401\s+insufficient permissions/i || $failure_message =~ /insufficient permissions/i)) {
    my $luna_payload=$set_payload;
-   if($tv_input ne "" && $active_picture_mode ne "") {
+   if(!$picture_mode_only && $tv_input ne "" && $active_picture_mode ne "") {
     $luna_payload={
      category => "picture\$".$tv_input.".".$active_picture_mode.".2d.x",
      settings => $settings_to_apply,
@@ -5849,25 +5880,39 @@ sub lg_picture_set_workflow (@) {
 	   }
 	  } elsif($picture_mode_only) {
 	   # An accepted setSystemSettings response is not proof: WebOS may accept
-	   # the write while leaving the selected input on its previous bank. Poll
-	   # the same public settings plane used by the proven client until the TV
-	   # independently reports the requested mode.
+	   # the write while leaving the selected input on its previous bank, so
+	   # poll getSystemSettings until it reports the requested mode. Two known
+	   # limits, both unresolved by this readback: it reads the same settings
+	   # plane the write updated, so it guards against ignored writes but not
+	   # against the settings database moving without a pipeline transition
+	   # (previously observed on C2 Dolby Vision modes and unrefuted -- this
+	   # route is live-validated SDR-only on a G3, PR #1); and like the write
+	   # it carries no input dimension, so if the TV is not actually on
+	   # $tv_input both sides act on whatever bank the TV considers
+	   # foreground. The wall-clock deadline keeps the whole poll well inside
+	   # lg.pm's 45s helper kill and the browser's 15s fetch timeout, so a
+	   # mismatch surfaces as this branch's crafted error rather than an
+	   # opaque timeout.
+	   my $poll_deadline=time() + 5;
+	   my $poll_timeout=($connect_timeout < 2) ? $connect_timeout : 2;
 	   for(my $read_attempt=0;$read_attempt<10;$read_attempt++) {
 	    $picture_mode_readback_attempts=$read_attempt + 1;
 	    my $followup=&lg_request($session,"get_picture_mode_after_${read_attempt}","settings/getSystemSettings",{
 	     category => "picture",
 	     keys => ["pictureMode"],
-	    },$connect_timeout + 2);
-	    if(ref($followup) eq "HASH" && ($followup->{"type"}||"") ne "error"
+	    },$poll_timeout);
+	    my ($followup_failed,$followup_failure_message)=&response_is_app_failure($followup);
+	    if(!$followup_failed && ref($followup) eq "HASH"
 	       && ref($followup->{"payload"}) eq "HASH"
 	       && ref($followup->{"payload"}{"settings"}) eq "HASH") {
 	     $observed_picture_mode=$followup->{"payload"}{"settings"}{"pictureMode"}||"";
 	     $settings_after=$followup->{"payload"}{"settings"};
-	     if(&lg_picture_mode_readback_matches($active_picture_mode,$observed_picture_mode,$signal_mode)) {
+	     if(&lg_picture_mode_readback_matches($active_picture_mode,$observed_picture_mode)) {
 	      $picture_mode_readback_verified=1;
 	      last;
 	     }
 	    }
+	    last if(time() >= $poll_deadline);
 	    select(undef,undef,undef,0.35) if($read_attempt<9);
 	   }
 	  } else {
@@ -5895,9 +5940,11 @@ sub lg_picture_set_workflow (@) {
 	   readback_attempts => $picture_mode_readback_attempts,
 	   response => $response,
 	  });
+	  # The front-end toasts this message and does not refresh the Display
+	  # card on error, so the resync instruction must travel in the message.
 	  my $message=$observed_picture_mode ne ""
-	   ? "LG TV acknowledged the picture-mode request for '$active_picture_mode' but remained on '$observed_picture_mode'."
-	   : "LG TV acknowledged the picture-mode request for '$active_picture_mode' but did not return a verified picture-mode readback.";
+	   ? "LG TV acknowledged the picture-mode request for '$active_picture_mode' but remained on '$observed_picture_mode'. Click Refresh on the Display card to resync the picture controls with the TV."
+	   : "LG TV acknowledged the picture-mode request for '$active_picture_mode' but did not return a verified picture-mode readback. Click Refresh on the Display card to resync the picture controls with the TV.";
 	  return &json_error($message,{
 	   ip => $ip,
 	   active_picture_mode => $active_picture_mode,
@@ -5906,6 +5953,7 @@ sub lg_picture_set_workflow (@) {
 	   picture_mode_readback_attempts => $picture_mode_readback_attempts,
 	   picture_mode_write_path => "ssap://settings/setSystemSettings",
 	   error_code => "picture-mode-readback-mismatch",
+	   repair_hint => "Click Refresh on the Display card to resync the picture controls.",
 	   raw_response => $response,
 	  });
 	 } elsif($panel_light_only && !%{$settings_after}) {
@@ -5921,13 +5969,18 @@ sub lg_picture_set_workflow (@) {
   $settings_after->{"pictureMode"}=$active_picture_mode if($active_picture_mode ne "");
  }
  &websocket_close($session);
+ # The readback-verification keys only mean something for mode-only writes;
+ # emitting picture_mode_readback_verified=false on every white-balance or
+ # panel-light success would read as a failed verification.
  &diag_log_append("picture_set:ok",{
   ip => $ip,
   picture_mode => $active_picture_mode,
   applied => $settings_to_apply,
   settings_after => $settings_after,
-  picture_mode_readback_verified => &json_bool($picture_mode_readback_verified),
-  picture_mode_readback_attempts => $picture_mode_readback_attempts,
+  ($picture_mode_only ? (
+   picture_mode_readback_verified => &json_bool($picture_mode_readback_verified),
+   picture_mode_readback_attempts => $picture_mode_readback_attempts,
+  ) : ()),
  });
  return &json_ok({
   ip => $ip,
@@ -5935,9 +5988,11 @@ sub lg_picture_set_workflow (@) {
   picture_settings => $settings_after,
   applied => $settings_to_apply,
   active_picture_mode => $active_picture_mode,
-	  picture_mode_readback_verified => &json_bool($picture_mode_readback_verified),
-	  picture_mode_readback_attempts => $picture_mode_readback_attempts,
-	  picture_mode_write_path => $picture_mode_only ? "ssap://settings/setSystemSettings" : "",
+	  ($picture_mode_only ? (
+	   picture_mode_readback_verified => &json_bool($picture_mode_readback_verified),
+	   picture_mode_readback_attempts => $picture_mode_readback_attempts,
+	   picture_mode_write_path => "ssap://settings/setSystemSettings",
+	  ) : ()),
 	  calibration_mode => &json_bool($keep_calibration_mode && $ddc_white_balance_only),
   hello_info => $auth->{"hello_info"},
   system_info => $auth->{"system_info"},


### PR DESCRIPTION
## What this fixes

Changing the LG picture mode from PGenerator could return success even though the TV remained in its previous mode.

Mode-only writes were being sent through an alert-backed Luna request scoped with `current_app` and a CEC-derived input dimension. On an LG OLED55G36LA, that route could acknowledge the command without moving the foreground HDMI picture-mode bank. The existing workflow also did not require an independent matching readback before reporting success.

## What changed

Picture-mode-only changes now:

1. Send a minimal public WebOS SSAP request through `settings/setSystemSettings`:

   ```json
   {
     "category": "picture",
     "settings": {
       "pictureMode": "<requested mode>"
     }
   }
   ```

2. Poll `settings/getSystemSettings` independently for up to five seconds.
3. Report success only when the TV returns the requested picture mode.
4. Return `picture-mode-readback-mismatch` with the requested mode, observed mode, attempt count and a Display-card refresh hint when verification fails.

Readback verification is mandatory for mode-only writes, including callers that request `skip_readback`.

## Readback matching

Verification normalises case and separators and recognises only known equivalent WebOS labels:

- `dolbyHdrCinema` ↔ `dolbyHdrCinemaDark`
- `game` ↔ `gameOptimizer`

It deliberately does not reuse the input alias mapper. That mapper collapses genuinely different modes—such as Energy Saving into Standard, Sports into Vivid, and Cinema Home into Cinema—which would recreate the false-success problem during verification.

If the public SSAP write is refused specifically for insufficient permissions, the helper performs one minimal Luna fallback write. Independent readback still decides whether the operation succeeded.

Verification fields are emitted only for picture-mode-only requests, leaving other picture controls unchanged.

## Scope

This PR changes only:

- `usr/sbin/pgenerator-lg`
- `tools/check_lg_picture_mode_regression.pl`

The existing renderer stop/start after a successful picture-mode change is unchanged. The temporary green/reset-like interval during renderer resynchronisation is a separate PGenerator behaviour and is not addressed here.

## Validation

### Automated

- 54 regression tests pass
- covers immediate and delayed success, stale state, missing readback, insufficient-permissions fallback, enum equivalence, distinct-mode rejection, payload shape and response metadata
- `perl -c usr/sbin/pgenerator-lg`: syntax OK
- diff whitespace validation passes

### Live hardware

The helper in this PR was deployed to a Raspberry Pi PGenerator and tested with:

- LG OLED55G36LA / 2023 G3
- webOS 23.25.55
- SDR over HDMI
- baseline picture mode: `expert2`
- `expert2 → cinema`: verified on the first readback
- independent read confirmed `cinema`
- `cinema → expert2`: verified on the first readback
- independent read confirmed `expert2`
- renderer resynchronised after both writes
- PGenerator remained healthy

The TV was restored to its original `expert2` mode after testing.

## Known limit

The readback uses the same WebOS settings plane as the write. It proves the mode that the TV reports as foreground, but it cannot independently prove the visible video-pipeline transition on every LG generation and signal type. This change has been live-tested on a G3 in SDR; the documented C2 Dolby Vision aliases are covered by regression tests but were not live-tested as part of this PR.
