### PR TITLE
Show node progress during 3D LUT generation

### DIFF
--- a/usr/bin/meter_lg_3d_autocal.pl
+++ b/usr/bin/meter_lg_3d_autocal.pl
@@ -8,7 +8,7 @@ use IO::Select ();
 use IO::Socket::INET ();
 use JSON::PP ();
 use MIME::Base64 ();
-use POSIX qw(strftime);
+use POSIX qw(strftime WNOHANG);
 use Time::HiRes qw(sleep time);
 
 our $PGAC_LOADED = 0;
@@ -149,6 +149,20 @@ sub write_state {
   $encoded=$json->encode(\%fallback);
  };
  return write_file($state_file,$encoded,0);
+}
+
+sub set_lut_calculation_progress {
+ my ($state,$stage,$current,$total,$active)=@_;
+ return if(ref($state) ne "HASH");
+ $current=int($current||0);
+ $total=int($total||0);
+ $current=0 if($current < 0);
+ $current=$total if($total > 0 && $current > $total);
+ $state->{"lut_calculation_active"}=json_bool($active);
+ $state->{"lut_calculation_stage"}=$stage||"3D LUT calculation";
+ $state->{"lut_calculation_current_nodes"}=$current;
+ $state->{"lut_calculation_total_nodes"}=$total;
+ write_state($state);
 }
 
 sub cancelled {
@@ -1751,11 +1765,12 @@ sub node_output_pct {
 }
 
 sub _generate_lut_cube_serial {
- my ($model,$size)=@_;
+ my ($model,$size,$progress_cb)=@_;
  $size ||= 17;
  my @nodes;
  my @u16;
  for(my $r=0;$r<$size;$r++) {
+  die "cancelled\n" if(cancelled());
   for(my $g=0;$g<$size;$g++) {
    for(my $b=0;$b<$size;$b++) {
     my $out=node_output_pct($model,$r,$g,$b,$size);
@@ -1764,6 +1779,7 @@ sub _generate_lut_cube_serial {
     push @nodes,{ in=>[$r,$g,$b], out_pct=>$out, out_12bit=>\@v } if(@nodes < 16 || ($r==$size-1 && $g==$size-1 && $b==$size-1));
    }
   }
+  $progress_cb->(($r+1)*$size*$size,$size**3) if(ref($progress_cb) eq "CODE");
  }
  return (\@u16,\@nodes);
 }
@@ -1795,10 +1811,11 @@ sub neutral_identity_output {
 }
 
 sub _generate_lut_lg_payload_serial {
- my ($model,$size)=@_;
+ my ($model,$size,$progress_cb)=@_;
  $size ||= 33;
  my @u16;
  for(my $b=0;$b<$size;$b++) {
+  die "cancelled\n" if(cancelled());
   for(my $g=0;$g<$size;$g++) {
    for(my $r=0;$r<$size;$r++) {
     my $out=node_output_pct($model,$r,$g,$b,$size);
@@ -1806,6 +1823,7 @@ sub _generate_lut_lg_payload_serial {
     push @u16,@v;
    }
   }
+  $progress_cb->(($b+1)*$size*$size,$size**3) if(ref($progress_cb) eq "CODE");
  }
  return \@u16;
 }
@@ -1834,58 +1852,115 @@ sub _lut_node_u16 {
  return map { int(clamp($_,0,100)*4095/100+0.5) } @{$out};
 }
 
+# Parallel LUT generation reports completed outer-axis slabs through one tiny
+# progress file per child. The parent remains the sole writer of the public
+# JSON state, avoiding child races while still exposing real node counts.
+# On cancellation the parent SIGKILLs the children (their compute loops never
+# check the flag) and returns failure; callers die "cancelled" after cleanup.
+sub _lut_wait_workers {
+ my ($jobs,$tmpdir,$plane_nodes,$total_nodes,$progress_cb)=@_;
+ my %pending=map { $_->[1] => $_ } @{$jobs};
+ my %completed;
+ my $last_total=0;
+ my $ok=1;
+ while(%pending) {
+  if(cancelled()) {
+   kill('KILL',keys %pending);
+   waitpid($_,0) foreach(keys %pending);
+   return 0;
+  }
+  foreach my $pid (keys %pending) {
+   my $job=$pending{$pid};
+   my ($w,$slabs)=($job->[0],$job->[2]);
+   my $raw=read_file("$tmpdir/w$w.progress");
+   $completed{$w}=int($1) if($raw =~ /^\s*(\d+)\s*$/);
+   my $result=waitpid($pid,WNOHANG);
+   if($result==$pid) {
+    my $exit_status=$?;
+    $ok=0 if(($exit_status >> 8) != 0 || ($exit_status & 127) != 0);
+    $completed{$w}=$slabs*$plane_nodes if(($exit_status >> 8) == 0 && ($exit_status & 127) == 0);
+    delete($pending{$pid});
+   } elsif($result < 0) {
+    $ok=0;
+    delete($pending{$pid});
+   }
+  }
+  my $done=0;
+  $done+=$_ foreach(values %completed);
+  $done=$total_nodes if($done > $total_nodes);
+  if($done != $last_total) {
+   $progress_cb->($done,$total_nodes) if(ref($progress_cb) eq "CODE");
+   $last_total=$done;
+  }
+  sleep(0.08) if(%pending);
+ }
+ return $ok;
+}
+
 sub generate_lut_cube {
- my ($model,$size)=@_;
+ my ($model,$size,$progress_cb)=@_;
  $size ||= 17;
  my $workers=_lut_gen_workers($size);
- return _generate_lut_cube_serial($model,$size) if($workers <= 1);
+ return _generate_lut_cube_serial($model,$size,$progress_cb) if($workers <= 1);
  my $tmpdir=sprintf("/tmp/lutcube_%d_%d", $$, time());
  if(!mkdir($tmpdir,0700)) {
   log_line("lut generate: mkdir $tmpdir failed ($!), serial cube");
-  return _generate_lut_cube_serial($model,$size);
+  return _generate_lut_cube_serial($model,$size,$progress_cb);
  }
  my $per=int(($size+$workers-1)/$workers);
  my @pids;
+ my $expected_workers=0;
  for(my $w=0;$w<$workers;$w++) {
   my $r0=$w*$per; my $r1=$r0+$per; $r1=$size if($r1 > $size);
   next if($r0 >= $size);
+  $expected_workers++;
   my $pid=fork();
   if(!defined $pid) { log_line("lut generate: fork failed on cube worker $w"); last; }
   if($pid == 0) {
-   my @u16;
-   for(my $r=$r0;$r<$r1;$r++) {
-    for(my $g=0;$g<$size;$g++) {
-     for(my $b=0;$b<$size;$b++) {
-      push @u16,_lut_node_u16($model,$r,$g,$b,$size);
+   $SIG{TERM}='DEFAULT'; $SIG{INT}='DEFAULT';
+   # A die here would unwind into the parent's top-level eval inside the
+   # child's copy of the script (state writes, upload paths) — never escape.
+   eval {
+    my @u16;
+    my $slabs_done=0;
+    for(my $r=$r0;$r<$r1;$r++) {
+     for(my $g=0;$g<$size;$g++) {
+      for(my $b=0;$b<$size;$b++) {
+       push @u16,_lut_node_u16($model,$r,$g,$b,$size);
+      }
      }
+     $slabs_done++;
+     write_file("$tmpdir/w$w.progress",$slabs_done*$size*$size,0);
     }
-   }
-   if(open(my $fh,'>',"$tmpdir/w$w.raw")) { binmode($fh); print $fh pack('S*',@u16); close($fh); }
+    if(open(my $fh,'>',"$tmpdir/w$w.raw")) { binmode($fh); print $fh pack('S*',@u16); close($fh); }
+    1;
+   } or exit 1;
    exit 0;
   }
-  push @pids,[$w,$pid];
+  push @pids,[$w,$pid,$r1-$r0];
  }
- my $ok=1;
- foreach my $job (@pids) {
-  my $cpid=waitpid($job->[1],0);
-  $ok=0 if($cpid < 0 || ($? >> 8) != 0);
- }
+ my $ok=(scalar(@pids)==$expected_workers) ? 1 : 0;
+ kill('KILL',map { $_->[1] } @pids) if(!$ok && @pids);
+ $ok=0 if(!_lut_wait_workers(\@pids,$tmpdir,$size*$size,$size**3,$progress_cb));
  my @u16;
- if($ok) {
-  for(my $w=0;$w<$workers;$w++) {
-   my $path="$tmpdir/w$w.raw";
-   next unless(-f $path);
+ for(my $w=0;$w<$workers;$w++) {
+  my $path="$tmpdir/w$w.raw";
+  if($ok && -f $path) {
    if(open(my $fh,'<',$path)) {
     binmode($fh); local $/; my $blob=<$fh>; close($fh);
     push @u16, unpack('S*',$blob) if(defined $blob && length($blob));
    }
-   unlink($path);
   }
+  unlink($path);
+  unlink("$tmpdir/w$w.progress");
+  unlink("$tmpdir/w$w.progress.tmp");
  }
  rmdir($tmpdir);
  if(!$ok || scalar(@u16) != 3*$size*$size*$size) {
+  die "cancelled\n" if(cancelled());
   log_line("lut generate: parallel cube failed (ok=$ok n=".scalar(@u16)."), serial fallback");
-  return _generate_lut_cube_serial($model,$size);
+  $progress_cb->(0,$size**3) if(ref($progress_cb) eq "CODE");
+  return _generate_lut_cube_serial($model,$size,$progress_cb);
  }
  log_line("lut generate: cube ${size}^3 via $workers workers");
  # Preview corners only — payload/export do not depend on these nodes.
@@ -1900,57 +1975,69 @@ sub generate_lut_cube {
 }
 
 sub generate_lut_lg_payload {
- my ($model,$size)=@_;
+ my ($model,$size,$progress_cb)=@_;
  $size ||= 33;
  my $workers=_lut_gen_workers($size);
- return _generate_lut_lg_payload_serial($model,$size) if($workers <= 1);
+ return _generate_lut_lg_payload_serial($model,$size,$progress_cb) if($workers <= 1);
  my $tmpdir=sprintf("/tmp/lutpay_%d_%d", $$, time());
  if(!mkdir($tmpdir,0700)) {
   log_line("lut generate: mkdir $tmpdir failed ($!), serial payload");
-  return _generate_lut_lg_payload_serial($model,$size);
+  return _generate_lut_lg_payload_serial($model,$size,$progress_cb);
  }
  my $per=int(($size+$workers-1)/$workers);
  my @pids;
+ my $expected_workers=0;
  for(my $w=0;$w<$workers;$w++) {
   my $b0=$w*$per; my $b1=$b0+$per; $b1=$size if($b1 > $size);
   next if($b0 >= $size);
+  $expected_workers++;
   my $pid=fork();
   if(!defined $pid) { log_line("lut generate: fork failed on payload worker $w"); last; }
   if($pid == 0) {
-   my @u16;
-   for(my $b=$b0;$b<$b1;$b++) {
-    for(my $g=0;$g<$size;$g++) {
-     for(my $r=0;$r<$size;$r++) {
-      push @u16,_lut_node_u16($model,$r,$g,$b,$size);
+   $SIG{TERM}='DEFAULT'; $SIG{INT}='DEFAULT';
+   # A die here would unwind into the parent's top-level eval inside the
+   # child's copy of the script (state writes, upload paths) — never escape.
+   eval {
+    my @u16;
+    my $slabs_done=0;
+    for(my $b=$b0;$b<$b1;$b++) {
+     for(my $g=0;$g<$size;$g++) {
+      for(my $r=0;$r<$size;$r++) {
+       push @u16,_lut_node_u16($model,$r,$g,$b,$size);
+      }
      }
+     $slabs_done++;
+     write_file("$tmpdir/w$w.progress",$slabs_done*$size*$size,0);
     }
-   }
-   if(open(my $fh,'>',"$tmpdir/w$w.raw")) { binmode($fh); print $fh pack('S*',@u16); close($fh); }
+    if(open(my $fh,'>',"$tmpdir/w$w.raw")) { binmode($fh); print $fh pack('S*',@u16); close($fh); }
+    1;
+   } or exit 1;
    exit 0;
   }
-  push @pids,[$w,$pid];
+  push @pids,[$w,$pid,$b1-$b0];
  }
- my $ok=1;
- foreach my $job (@pids) {
-  my $cpid=waitpid($job->[1],0);
-  $ok=0 if($cpid < 0 || ($? >> 8) != 0);
- }
+ my $ok=(scalar(@pids)==$expected_workers) ? 1 : 0;
+ kill('KILL',map { $_->[1] } @pids) if(!$ok && @pids);
+ $ok=0 if(!_lut_wait_workers(\@pids,$tmpdir,$size*$size,$size**3,$progress_cb));
  my @u16;
- if($ok) {
-  for(my $w=0;$w<$workers;$w++) {
-   my $path="$tmpdir/w$w.raw";
-   next unless(-f $path);
+ for(my $w=0;$w<$workers;$w++) {
+  my $path="$tmpdir/w$w.raw";
+  if($ok && -f $path) {
    if(open(my $fh,'<',$path)) {
     binmode($fh); local $/; my $blob=<$fh>; close($fh);
     push @u16, unpack('S*',$blob) if(defined $blob && length($blob));
    }
-   unlink($path);
   }
+  unlink($path);
+  unlink("$tmpdir/w$w.progress");
+  unlink("$tmpdir/w$w.progress.tmp");
  }
  rmdir($tmpdir);
  if(!$ok || scalar(@u16) != 3*$size*$size*$size) {
+  die "cancelled\n" if(cancelled());
   log_line("lut generate: parallel payload failed (ok=$ok n=".scalar(@u16)."), serial fallback");
-  return _generate_lut_lg_payload_serial($model,$size);
+  $progress_cb->(0,$size**3) if(ref($progress_cb) eq "CODE");
+  return _generate_lut_lg_payload_serial($model,$size,$progress_cb);
  }
  log_line("lut generate: payload ${size}^3 via $workers workers");
  return \@u16;
@@ -2353,7 +2440,12 @@ sub run_solve_only {
  $state->{"current_name"}="Generating ${cube_size}³ cube";
  $state->{"solve_progress_pct"}=45;
  write_state($state);
- my ($cube_u16,$preview_nodes)=generate_lut_cube($model,$cube_size);
+ set_lut_calculation_progress($state,"Export cube calculation",0,$cube_size**3,1);
+ my ($cube_u16,$preview_nodes)=generate_lut_cube($model,$cube_size,sub {
+  my ($current,$total)=@_;
+  set_lut_calculation_progress($state,"Export cube calculation",$current,$total,1);
+ });
+ set_lut_calculation_progress($state,"Export cube calculation",$cube_size**3,$cube_size**3,0);
  $model->{"method"}=$series_method;
  $state->{"message"}="Writing ${cube_size}³ .cube export";
  $state->{"current_name"}="Writing .cube";
@@ -4348,7 +4440,11 @@ if($config->{"solve_only"}) {
  eval { run_solve_only($config); };
  if($@) {
   my $err=$@; $err =~ s/\s+$//;
-  write_state({ status=>"error", solve_only=>json_true(), message=>"LUT solve failed: $err" });
+  if($err =~ /^cancelled$/i) {
+   write_state({ status=>"cancelled", solve_only=>json_true(), message=>"LUT solve cancelled" });
+  } else {
+   write_state({ status=>"error", solve_only=>json_true(), message=>"LUT solve failed: $err" });
+  }
   exit 1;
  }
  exit 0;
@@ -4610,12 +4706,22 @@ eval {
  $state->{"current_name"}="Generating ${cube_size}³ cube";
  $state->{"solve_progress_pct"}=40;
  write_state($state);
- ($cube_u16,$preview_nodes)=generate_lut_cube($model,$cube_size);
+ set_lut_calculation_progress($state,"Export cube calculation",0,$cube_size**3,1);
+ ($cube_u16,$preview_nodes)=generate_lut_cube($model,$cube_size,sub {
+  my ($current,$total)=@_;
+  set_lut_calculation_progress($state,"Export cube calculation",$current,$total,1);
+ });
+ set_lut_calculation_progress($state,"Export cube calculation",$cube_size**3,$cube_size**3,0);
  $state->{"message"}="Generating 33-point LG upload payload";
  $state->{"current_name"}="Generating 33³ payload";
  $state->{"solve_progress_pct"}=70;
  write_state($state);
- $payload_u16=generate_lut_lg_payload($model,33);
+ set_lut_calculation_progress($state,"LG 33³ payload calculation",0,33**3,1);
+ $payload_u16=generate_lut_lg_payload($model,33,sub {
+  my ($current,$total)=@_;
+  set_lut_calculation_progress($state,"LG 33³ payload calculation",$current,$total,1);
+ });
+ set_lut_calculation_progress($state,"LG 33³ payload calculation",33**3,33**3,0);
  }
  my $export=export_lut($cube_u16,$payload_u16,$model,$config,$cube_size);
  $state->{"export"}=$export;
@@ -5032,6 +5138,11 @@ eval {
  $state->{"phase"}=$state->{"status"};
  $state->{"current_name"}=$state->{"status"} eq "cancelled" ? "LG 3D LUT Auto Cal cancelled" : "LG 3D LUT Auto Cal error";
  $state->{"message"}=$state->{"status"} eq "cancelled" ? "3D LUT Auto Cal stopped" : $err;
+ if($state->{"lut_calculation_active"}) {
+  $state->{"lut_calculation_active"}=json_false();
+  $state->{"lut_calculation_current_nodes"}=0;
+  $state->{"lut_calculation_total_nodes"}=0;
+ }
  write_state($state);
  log_line($err);
 };

--- a/usr/share/PGenerator/webui.pm
+++ b/usr/share/PGenerator/webui.pm
@@ -10852,7 +10852,12 @@ body.meter-autocal-active .meter-autocal-mask{display:flex}
 .meter-workflow-progress-fill{height:100%;width:0;min-width:0;background:linear-gradient(90deg,#5d6dff 0%,#4d8df7 45%,#39d06f 100%);box-shadow:0 0 12px rgba(76,175,80,.35),inset 0 1px 0 rgba(255,255,255,.24);transition:width .28s ease,min-width .18s ease;position:relative;overflow:hidden;border-radius:3px}
 .meter-workflow-progress-fill.active{min-width:10px}
 .meter-workflow-progress-fill.active::after{content:"";position:absolute;inset:-40% -25%;background:linear-gradient(105deg,transparent 0%,rgba(255,255,255,.06) 34%,rgba(255,255,255,.46) 50%,rgba(255,255,255,.06) 66%,transparent 100%);transform:translateX(-115%);animation:meterProgressShimmer 1.65s ease-in-out infinite}
-@media(max-width:720px){.meter-workflow-progress-wrap{grid-template-columns:minmax(0,1fr) auto}.meter-workflow-progress{grid-column:1 / -1;grid-row:2}}
+.meter-lut-calculation-progress{display:grid;grid-template-columns:minmax(260px,.9fr) minmax(180px,2fr) auto;align-items:center;gap:10px;margin:0 0 8px;color:var(--text2);font-size:.68rem}
+.meter-lut-calculation-label{overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.meter-lut-calculation-count{font-variant-numeric:tabular-nums;white-space:nowrap}
+.meter-lut-calculation-bar{height:6px;border-radius:999px;background:#0d0f18;border:1px solid rgba(255,255,255,.12);overflow:hidden}
+.meter-lut-calculation-fill{height:100%;width:0;background:linear-gradient(90deg,#5d6dff,#4d8df7);transition:width .2s ease}
+@media(max-width:720px){.meter-workflow-progress-wrap{grid-template-columns:minmax(0,1fr) auto}.meter-workflow-progress{grid-column:1 / -1;grid-row:2}.meter-lut-calculation-progress{grid-template-columns:minmax(0,1fr) auto}.meter-lut-calculation-bar{grid-column:1 / -1;grid-row:2}}
 .offline-mask-title{font-size:1rem;font-weight:700;margin-bottom:6px}
 .offline-mask-text{font-size:.85rem;line-height:1.45;color:var(--text2)}
 .status-bar{display:flex;align-items:center;justify-content:flex-end;gap:10px;min-width:0;font-size:.8rem;color:var(--text2)}
@@ -12359,6 +12364,11 @@ body.layout-tablet .ui-choice:disabled:hover .ui-choice-description,body.layout-
    </div>
    <div id="meterWorkflowProgressBar" class="meter-workflow-progress"><div id="meterWorkflowProgressFill" class="meter-workflow-progress-fill"></div></div>
    <span id="meterProgressPercent" class="meter-workflow-progress-percent"></span>
+  </div>
+  <div id="meterLutCalculationProgress" class="meter-lut-calculation-progress" style="display:none">
+   <span id="meterLutCalculationLabel" class="meter-lut-calculation-label">3D LUT calculation</span>
+   <div id="meterLutCalculationBar" class="meter-lut-calculation-bar" role="progressbar" aria-valuemin="0"><div id="meterLutCalculationFill" class="meter-lut-calculation-fill"></div></div>
+   <span id="meterLutCalculationCount" class="meter-lut-calculation-count">0 / 0 nodes</span>
   </div>
 
   <div id="meterGreyProfileModal" style="display:none;position:fixed;inset:0;background:rgba(0,0,0,.7);z-index:10000;align-items:center;justify-content:center;padding:18px;box-sizing:border-box">
@@ -26595,6 +26605,45 @@ function meterSetWorkflowProgress(status,options){
  }
 }
 
+function meterFormatNodeCount(value){
+ return Math.round(value).toLocaleString('en-GB');
+}
+
+function meterUpdateLutCalculationProgress(status){
+ const wrap=document.getElementById('meterLutCalculationProgress');
+ const label=document.getElementById('meterLutCalculationLabel');
+ const count=document.getElementById('meterLutCalculationCount');
+ const bar=document.getElementById('meterLutCalculationBar');
+ const fill=document.getElementById('meterLutCalculationFill');
+ const current=Math.max(0,Number(status&&status.lut_calculation_current_nodes)||0);
+ const total=Math.max(0,Number(status&&status.lut_calculation_total_nodes)||0);
+ const active=!!(status&&status.lut_calculation_active&&String(status.status||'').toLowerCase()==='running'&&total>0);
+ if(!active){
+  meterHideLutCalculationProgress();
+  return;
+ }
+ const safeCurrent=Math.min(current,total);
+ const pct=total>0?Math.max(0,Math.min(100,100*safeCurrent/total)):0;
+ if(wrap) wrap.style.display='grid';
+ if(label) label.textContent=String(status.lut_calculation_stage||'3D LUT calculation');
+ if(count) count.textContent=meterFormatNodeCount(safeCurrent)+' / '+meterFormatNodeCount(total)+' nodes';
+ if(fill) fill.style.width=pct+'%';
+ if(bar){
+  bar.setAttribute('aria-valuemax',String(Math.round(total)));
+  bar.setAttribute('aria-valuenow',String(Math.round(safeCurrent)));
+  bar.setAttribute('aria-valuetext',meterFormatNodeCount(safeCurrent)+' of '+meterFormatNodeCount(total)+' nodes');
+ }
+}
+
+function meterHideLutCalculationProgress(){
+ const wrap=document.getElementById('meterLutCalculationProgress');
+ const fill=document.getElementById('meterLutCalculationFill');
+ const bar=document.getElementById('meterLutCalculationBar');
+ if(wrap) wrap.style.display='none';
+ if(fill) fill.style.width='0%';
+ if(bar){ bar.removeAttribute('aria-valuenow'); bar.removeAttribute('aria-valuetext'); }
+}
+
 function meterClearWorkflowProgress(){
  const pctText=document.getElementById('meterProgressPercent');
  const bar=document.getElementById('meterWorkflowProgressBar');
@@ -26611,6 +26660,7 @@ function meterHideWorkflowProgress(){
  const progress=document.getElementById('meterProgress');
  if(progress) progress.style.display='none';
  meterClearWorkflowProgress();
+ meterHideLutCalculationProgress();
 }
 
 function meterHideProgressIfIdle(){
@@ -27489,6 +27539,7 @@ function meterClearInteractiveSelection(keepLiveReading){
  if(!keepLiveReading){
   document.getElementById('meterLiveReading').style.display='none';
   document.getElementById('meterProgress').style.display='none';
+  meterHideLutCalculationProgress();
  }
  meterUpdateReadButtons();
 }
@@ -30964,6 +31015,11 @@ function meterLutSolveProgressUpdate(status){
  const sz=Number(s.cube_lut_size||s.solve_cube_size||0);
  if(sz===17||sz===33||sz===65) bits.push(sz+'³ export');
  if(s.lattice_nodes!=null) bits.push(s.lattice_nodes+' profile nodes');
+ const nodeCurrent=Math.max(0,Number(s.lut_calculation_current_nodes)||0);
+ const nodeTotal=Math.max(0,Number(s.lut_calculation_total_nodes)||0);
+ const nodeProgress=!!(s.lut_calculation_active&&nodeTotal>0);
+ // Bar tracks the monotonic stage bands; per-stage node counts restart at
+ // zero for each stage, so they feed the detail line only.
  const pct=Number(s.solve_progress_pct);
  if(Number.isFinite(pct)&&pct>=0){
   if(fill){
@@ -30971,6 +31027,7 @@ function meterLutSolveProgressUpdate(status){
    fill.style.width=Math.max(8,Math.min(100,pct))+'%';
   }
   bits.push(Math.round(Math.min(100,pct))+'%');
+  if(nodeProgress) bits.push(meterFormatNodeCount(Math.min(nodeCurrent,nodeTotal))+' / '+meterFormatNodeCount(nodeTotal)+' nodes');
  } else if(fill){
   // Indeterminate shimmer while the worker has no percent yet.
   const cur=parseFloat(fill.style.width)||12;
@@ -31026,12 +31083,12 @@ async function meterLutSolvePoll(){
   }
   return;
  }
- if(s.status==='error'){
+ if(s.status==='error'||s.status==='cancelled'){
   if(meterLutSolvePolling){ clearInterval(meterLutSolvePolling); meterLutSolvePolling=null; }
   meterLutSolvePendingDownload='';
   meterBuild3dLutPending=null;
   meterLutSolveProgressHide();
-  toast(s.message||'LUT solve failed',true);
+  toast(s.message||'LUT solve failed',s.status==='error');
  }
 }
 
@@ -40135,6 +40192,7 @@ function meterLg3dApplyStatus(status){
  const labelText=(status.current_name||status.message||'LG 3D LUT AutoCal')+(summary?' | '+summary:'');
  if(status.status==='running') meterSetWorkflowProgress(status,{workflow:meterFullAutoCalRunning?'full':'3d-lut',label:labelText});
  else meterHideWorkflowProgress();
+ meterUpdateLutCalculationProgress(status);
  if(status.status==='running'){
   meterLg3dAutoCalRunning=true;
   meterActionPending=false;
@@ -47077,6 +47135,7 @@ function meterApplyClearedState(showToastMsg){
  _selectedColorReadingName=null;
  _colorDetailPinned=false;
  document.getElementById('meterProgress').style.display='none';
+ meterHideLutCalculationProgress();
  document.getElementById('meterLiveReading').style.display='none';
  document.getElementById('meterExportRow').style.display='none';
  meterResetLiveReadingDisplay();


### PR DESCRIPTION
## What changed

This adds a compact calculation-progress row directly beneath the existing Full Auto Cal progress bar while a 3D LUT is being generated.

The new row shows:

- the active calculation stage, such as **Export cube calculation** or **LG 33³ payload calculation**
- an exact node counter, for example **12,672 / 35,937 nodes**
- a slim, responsive progress bar with progress-bar accessibility metadata

The 3D LUT worker now reports real completed-node counts for both serial and parallel generation. Parallel child workers write small per-worker progress sidecars, which the parent aggregates before updating the public status JSON. The parent remains the only process writing public run state, avoiding state-file races.

The standalone LUT solve modal also surfaces the exact node count. Cancellation now stops parallel calculation children and cleans up their temporary files rather than leaving CPU-intensive workers behind.

## Why

After profiling finishes, 3D LUT generation can keep a Raspberry Pi at 100% CPU for a significant period. Previously the UI only moved between coarse solve milestones, so it could appear frozen even though the Pi was actively calculating the LUT.

A 33³ LG upload payload contains 35,937 nodes. Showing the real X/Y node count gives the operator clear evidence that work is progressing and distinguishes a healthy long-running solve from a stalled process.

## Impact

This does not change the calibration maths or generated LUT values. It adds progress callbacks around the existing node calculation and exposes that state in the UI.

The additional row is hidden outside active LUT calculation, works in Full Auto Cal and standalone solve flows, and adapts to narrow/mobile layouts.

## Validation

- `perl -c usr/bin/meter_lg_3d_autocal.pl`
- `perl -c usr/share/PGenerator/webui.pm`
- Embedded Web UI JavaScript checked with `node --check`
- `git diff --check`
- Real 65³ solve completed with 274,625 / 274,625 nodes and produced a valid cube export
- Deployed to Raspberry Pi hardware; the restarted service returned HTTP 200 and a healthy `/api/ping` response
