### PR TITLE
Harden LG AutoCal convergence, picture-mode handling and 3D LUT progress

### DIFF
--- a/t/00-compile.t
+++ b/t/00-compile.t
@@ -1,0 +1,42 @@
+#
+# Syntax check for the files most exposed to hand surgery.
+#
+# Deleting a sub from an 85,000-line Perl tree is the kind of change that
+# looks clean in a diff and fails at runtime on the Pi, mid-calibration. A
+# compile check is cheap, needs no hardware, and catches the single most
+# likely real breakage.
+#
+use strict;
+use warnings;
+use Test::More;
+use FindBin qw($Bin);
+use File::Spec ();
+use lib "$FindBin::Bin/lib";
+use PGenSource qw(repo_root source_path);
+
+my $root=repo_root($Bin);
+
+my @sources=qw(
+ usr/share/PGenerator/lg.pm
+ usr/share/PGenerator/webui.pm
+ usr/bin/meter_lg_autocal.pl
+ usr/sbin/pgenerator-lg
+ tools/check_lg_picture_mode_regression.pl
+);
+
+foreach my $relative (@sources) {
+ my $path=source_path($root,$relative);
+ if(!-f $path) {
+  fail("$relative exists");
+  next;
+ }
+ my $log=File::Spec->catfile(File::Spec->tmpdir(),"pgen-compile-$$-".($relative=~s{/}{_}gr).".log");
+ my $rc=system(qq{"$^X" -c "$path" >"$log" 2>&1});
+ my $output="";
+ if(open(my $fh,"<",$log)) { local $/; $output=<$fh>; close($fh); }
+ unlink($log);
+ ok($rc==0 && $output=~/syntax OK/,"$relative compiles")
+  or diag($output);
+}
+
+done_testing();

--- a/t/00-compile.t
+++ b/t/00-compile.t
@@ -17,9 +17,11 @@ use PGenSource qw(repo_root source_path);
 my $root=repo_root($Bin);
 
 my @sources=qw(
+ usr/share/PGenerator/PGAutoCalSafety.pm
  usr/share/PGenerator/lg.pm
  usr/share/PGenerator/webui.pm
  usr/bin/meter_lg_autocal.pl
+ usr/bin/meter_lg_3d_autocal.pl
  usr/sbin/pgenerator-lg
  tools/check_lg_picture_mode_regression.pl
 );

--- a/t/autocal_safety_guards.t
+++ b/t/autocal_safety_guards.t
@@ -1,0 +1,178 @@
+use strict;
+use warnings;
+use Test::More;
+use FindBin qw($Bin);
+use lib "$Bin/../usr/share/PGenerator";
+use lib "$Bin/lib";
+use PGenSource qw(repo_root slurp_source);
+use PGAutoCalSafety qw(
+ profile_reading_plausibility_error
+ profile_primary_monotonicity_error
+ critical_shadow_needs_revisit
+ autocal_solver_target_delta_e
+ autocal_white_residual_stop_allowed
+ autocal_restored_acceptance_needs_retry
+);
+
+my $blue90_step={kind=>'node',level=>90,signal_r_pct=>0,signal_g_pct=>0,signal_b_pct=>90};
+my $blue100_step={kind=>'blue',level=>100,signal_r_pct=>0,signal_g_pct=>0,signal_b_pct=>100};
+my $blue90={X=>98.516228,Y=>29.080523,Z=>538.163308};
+my $blue100_good={X=>126.439449,Y=>37.272399,Z=>691.188413};
+my $blue100_bad={X=>0,Y=>0,Z=>0};
+
+like(
+ profile_reading_plausibility_error($blue100_step,$blue100_bad),
+ qr/non-black patch returned black XYZ/,
+ 'exact-zero blue endpoint is rejected'
+);
+is(
+ profile_reading_plausibility_error($blue100_step,$blue100_good),
+ undef,
+ 'valid blue endpoint passes the absolute plausibility gate'
+);
+is(
+ profile_reading_plausibility_error({kind=>'black',level=>0,signal_r_pct=>0,signal_g_pct=>0,signal_b_pct=>0},$blue100_bad),
+ undef,
+ 'a genuine black patch may read XYZ zero'
+);
+is(
+ profile_primary_monotonicity_error($blue100_step,$blue100_good,[{step=>$blue90_step,reading=>$blue90}]),
+ undef,
+ 'a monotonic 90-to-100 blue ramp passes'
+);
+like(
+ profile_primary_monotonicity_error($blue100_step,{X=>20,Y=>5,Z=>100},[{step=>$blue90_step,reading=>$blue90}]),
+ qr/blue ramp collapsed/,
+ 'a non-zero but collapsed blue endpoint is rejected'
+);
+
+ok(
+ critical_shadow_needs_revisit({ire=>2.3},0),
+ 'an unconverged 2.3% shadow anchor is queued for revisit'
+);
+ok(
+ !critical_shadow_needs_revisit({ire=>2.3},1),
+ 'a converged 2.3% shadow anchor is not revisited'
+);
+ok(
+ !critical_shadow_needs_revisit({ire=>2.0},0),
+ 'other dark-detail samples do not trigger the critical 2.3% revisit'
+);
+
+is(
+ autocal_solver_target_delta_e({target_delta_e=>0.2},'lg_autocal_sdr26_dpg_target_de',0.5),
+ 0.2,
+ 'the SDR DPG solver inherits the operator-selected dE target'
+);
+is(
+ autocal_solver_target_delta_e({target_delta_e=>0.2,lg_autocal_sdr26_dpg_target_de=>0.35},'lg_autocal_sdr26_dpg_target_de',0.5),
+ 0.35,
+ 'an explicit solver-specific target overrides the operator target'
+);
+is(
+ autocal_solver_target_delta_e({target_delta_e=>10},'lg_autocal_hdr20_dpg_target_de',0.5),
+ 10,
+ 'the full WebUI target range reaches the specialised solver unchanged'
+);
+is(
+ autocal_solver_target_delta_e({target_delta_e=>'invalid'},'lg_autocal_hdr20_dpg_target_de',0.5),
+ 0.5,
+ 'an invalid target falls back safely'
+);
+
+ok(
+ !autocal_white_residual_stop_allowed(1,0,0.0038,0.218,0.2),
+ 'a small white residual cannot stop an above-target solve on its first attempt'
+);
+ok(
+ !autocal_white_residual_stop_allowed(3,1,0.0038,0.218,0.2),
+ 'one revert is not enough to abandon an above-target white solve early'
+);
+ok(
+ autocal_white_residual_stop_allowed(4,0,0.0038,0.218,0.2),
+ 'the residual shortcut is available after four genuine attempts'
+);
+ok(
+ autocal_white_residual_stop_allowed(3,2,0.0038,0.218,0.2),
+ 'two reverts permit the bounded residual give-up path'
+);
+ok(
+ !autocal_white_residual_stop_allowed(4,2,0.0038,0.19,0.2),
+ 'the residual shortcut is irrelevant once white has reached the target'
+);
+
+ok(
+ autocal_restored_acceptance_needs_retry(1,0.2504,0.2),
+ 'a successful restoration reread above target must continue solving'
+);
+ok(
+ !autocal_restored_acceptance_needs_retry(1,0.1789,0.2),
+ 'a successful restoration reread below target may finish the anchor'
+);
+ok(
+ !autocal_restored_acceptance_needs_retry(0,0.2504,0.2),
+ 'a failed restoration reread does not drive a move from an unverified reading'
+);
+
+my $root=repo_root($Bin);
+my $grey_source=slurp_source($root,'usr/bin/meter_lg_autocal.pl');
+like(
+ $grey_source,
+ qr/Auto Cal complete with warning/,
+ 'an unresolved critical-shadow revisit is visible in the terminal state'
+);
+my $sdr_target_uses=()=$grey_source=~/autocal_solver_target_delta_e\(\$config,"lg_autocal_sdr26_dpg_target_de",0\.5\)/g;
+is($sdr_target_uses,2,'both SDR DPG layers use the operator-aware target resolver');
+my $hdr_target_uses=()=$grey_source=~/autocal_solver_target_delta_e\(\$config,"lg_autocal_hdr20_dpg_target_de",0\.5\)/g;
+is($hdr_target_uses,1,'the HDR and Dolby Vision DPG worker uses the operator-aware target resolver');
+like(
+ $grey_source,
+ qr/HDR20 1D DPG greyscale: active target dE=/,
+ 'the HDR and Dolby Vision worker logs its resolved target for live verification'
+);
+unlike(
+ $grey_source,
+ qr/lg_autocal_(?:hdr20|sdr26)_dpg_target_de_(?:low|very_low)_multiplier"\}\) \? \([^\n]+\) : (?:1\.5|2\.0)/,
+ 'low-IRE DPG thresholds do not relax the requested target by default'
+);
+unlike(
+ $grey_source,
+ qr/lg_autocal_(?:hdr20|sdr26)_dpg_low_ire_close_factor"\}\) \? \([^\n]+\) : 1\.5/,
+ 'the low-IRE near-target shortcut cannot stop above target by default'
+);
+unlike(
+ $grey_source,
+ qr/(?:hdr20|sdr)_1d_dpg_white_converged"\}=\(\$conv \|\| \$white_usable\)/,
+ 'a usable white is not falsely labelled as converged'
+);
+like(
+ $grey_source,
+ qr/remained above the requested dE target/,
+ 'an exhausted exact-target solve is surfaced as a warning'
+);
+my $restored_retry_uses=()=$grey_source=~/autocal_restored_acceptance_needs_retry\(/g;
+is($restored_retry_uses,2,'both HDR and SDR refinement restores recheck the active target');
+like(
+ $grey_source,
+ qr/restoration verify dE=.*still above target.*continuing solve/,
+ 'an above-target restoration is explicit in the live log'
+);
+my $colour_source=slurp_source($root,'usr/bin/meter_lg_3d_autocal.pl');
+like(
+ $colour_source,
+ qr/read_validated_profile_step\(\$config,\$step,\$state,\\\@profile_readings\)/,
+ 'the 3D profile loop uses the validated measurement path'
+);
+like(
+ $colour_source,
+ qr/postcal_shadow_final_recommit_verified/,
+ 'a successful final shadow re-commit clears the stale re-establish failure state'
+);
+
+my $webui_source=slurp_source($root,'usr/share/PGenerator/webui.pm');
+my $hdr_target_posts=()=$webui_source=~/lg_autocal_hdr20_dpg_target_de:target/g;
+my $sdr_target_posts=()=$webui_source=~/lg_autocal_sdr26_dpg_target_de:target/g;
+is($hdr_target_posts,3,'every WebUI greyscale start path posts the HDR/DV worker target explicitly');
+is($sdr_target_posts,3,'every WebUI greyscale start path posts the SDR worker target explicitly');
+
+done_testing();

--- a/t/autocal_ui_repaint.t
+++ b/t/autocal_ui_repaint.t
@@ -1,0 +1,43 @@
+#
+# Contract: live LG greyscale AutoCal status polling must not repaint every
+# chart and persist the full series cache when the measurements are unchanged.
+#
+# A long convergence run polls for status roughly every 1.5 seconds. Canvas
+# painting and localStorage serialisation are main-thread work, so bypassing
+# the existing frame-budgeted greyscale painter makes the whole WebUI judder.
+#
+use strict;
+use warnings;
+use Test::More;
+use FindBin qw($Bin);
+use lib "$FindBin::Bin/lib";
+use PGenSource qw(repo_root slurp_source code_only slice_between);
+
+my $root=repo_root($Bin);
+my $webui=slurp_source($root,"usr/share/PGenerator/webui.pm");
+my $apply=slice_between(
+ $webui,
+ qr/async function meterAutoCalApplyStatus\(status\)\{/,
+ qr/function meterFullAutoCalCloneValue\(value\)\{/
+);
+
+ok(defined($apply),"AutoCal status renderer is locatable");
+
+SKIP: {
+ skip "AutoCal status renderer not locatable",5 if(!defined($apply));
+ my $code=code_only($apply,"js");
+
+ like($code,qr/const chartChanged=.*meterLastChartSignature/,
+  "AutoCal compares a stable chart signature before repainting");
+ like($code,qr/if\(statusRunning\)\{\s*if\(chartChanged\)\{/s,
+  "unchanged running polls bypass chart and cache work");
+ like($code,qr/meterQueueRunningGreyscaleChartRefresh\(sorted\)/,
+  "running AutoCal uses the frame-budgeted greyscale painter");
+ like($code,qr/\}else\{\s*meterCancelRunningGreyscaleChartRefresh\(\).*?drawAllCharts\(sorted\)/s,
+  "terminal AutoCal cancels queued work before its final synchronous paint");
+
+ my $running=()=($code=~/meterCacheSeriesState\(status\.status\|\|'running'\)/g);
+ is($running,1,"the running cache write exists only in the changed-chart branch");
+}
+
+done_testing();

--- a/t/cec_autocal_contract.t
+++ b/t/cec_autocal_contract.t
@@ -1,0 +1,222 @@
+#
+# Contract: CEC power is advisory, not a reachability gate.
+#
+# A TV can remain reachable through WebOS while CEC is unknown, stale, or
+# reporting standby, so a CEC reading must not decide whether an AutoCal
+# request reaches the real transport and picture-setting preflights.
+#
+# The corollary this file also has to protect: CEC was doing a second,
+# unrelated job on the read-only picture-settings poll -- keeping a dark panel
+# from occupying the single serialized WebUI worker for a full helper wrapper.
+# Dropping the CEC gate is a deliberate design choice; dropping that bound is
+# not. See "read-only poll" below.
+#
+use strict;
+use warnings;
+use Test::More;
+use FindBin qw($Bin);
+use lib "$FindBin::Bin/lib";
+use PGenSource qw(repo_root slurp_source code_only slice_between code_lines_between scan_tree);
+
+my $root=repo_root($Bin);
+my $webui=slurp_source($root,"usr/share/PGenerator/webui.pm");
+my $lg=slurp_source($root,"usr/share/PGenerator/lg.pm");
+my $worker=slurp_source($root,"usr/bin/meter_lg_autocal.pl");
+
+# A CEC power reading, in any of the spellings this codebase uses for one.
+my $CEC_POWER=qr/\bcec\b|tv_power|tv_off|powered\s+off|\bstandby\b|powering-o[nf]/i;
+
+#############################################################################
+# 1. No launch path gains a preflight of any kind between "is an LG selected"
+#    and its existing transport checks.
+#
+# These assert the FULL expected statement sequence rather than the absence of
+# CEC keywords. A keyword blacklist is defeated by naming a gate something
+# else -- require_lg_panel_awake() contains no CEC term at all. An exact
+# sequence cannot be: any inserted statement fails, whatever it is called.
+#
+# When a launch path legitimately gains a step, update the expected list here.
+# That edit is the point: it forces the change to be deliberate and reviewed.
+#############################################################################
+
+my @launch_paths=(
+ {
+  name     => "browser greyscale AutoCal launch",
+  source   => $webui,
+  style    => "js",
+  start    => qr/if\(!meterAutoCalAvailable\(\)\) return fail\(/,
+  end      => qr/if\(!meterEnsureAppliedGeneratorSettings\(\)\)/,
+  expected => [
+   "meterAutoCalWizardContextActive=true;",
+   "if(!(await meterEnsureLgAutoCalTransport(fullWorkflow?'Full Auto Cal':'LG Greyscale Auto Cal'))) return fail('');",
+   "if(!meterEnsureLgAutoCalExtendedVideoTransport()) return fail('');",
+  ],
+ },
+ {
+  name     => "browser Full AutoCal launch",
+  source   => $webui,
+  style    => "js",
+  start    => qr/if\(!meterFullAutoCalAvailable\(\)\)\{toast\(/,
+  end      => qr/if\(!meterEnsureAppliedGeneratorSettings\(\)\)/,
+  expected => [
+   "if(!(await meterEnsureLgAutoCalTransport('Full Auto Cal'))) return;",
+   "if(!meterEnsureLgAutoCalExtendedVideoTransport()) return;",
+  ],
+ },
+ {
+  name     => "server AutoCal launch",
+  source   => $webui,
+  style    => "perl",
+  start    => qr/LG 3D LUT AutoCal is already running/,
+  end      => qr/&webui_meter_stop\(\);/,
+  expected => [],
+ },
+ {
+  name     => "worker AutoCal preflight",
+  source   => $worker,
+  style    => "perl",
+  start    => qr/die "No greyscale steps were supplied"/,
+  end      => qr/my \$picture_response=read_initial_picture_settings\(/,
+  expected => [
+   'my $level_restore_error=restore_factory_levels_for_autocal($config,$state);',
+   'die $level_restore_error if($level_restore_error);',
+   'my $reset_error=reset_ddc_baseline_for_autocal($config,$state);',
+   'die $reset_error if($reset_error);',
+   'my $hdr_lum_reset_error=reset_hdr20_luminance_baseline_if_needed($config,$state);',
+   'die $hdr_lum_reset_error if($hdr_lum_reset_error);',
+  ],
+ },
+);
+
+foreach my $path (@launch_paths) {
+ my $lines=code_lines_between($path->{"source"},$path->{"start"},$path->{"end"},$path->{"style"});
+ if(!defined($lines)) {
+  fail("$path->{name}: both anchors still present");
+  next;
+ }
+ is_deeply($lines,$path->{"expected"},
+  "$path->{name}: reaches its preflights with no interposed check");
+}
+
+#############################################################################
+# 2. The read-only picture-settings poll does not gate on CEC -- and is still
+#    bounded so a dark panel cannot hold the single WebUI worker.
+#############################################################################
+
+my $picture_read=slice_between($lg,qr/sub webui_lg_picture_settings \(\@\) \{/,qr/action => "picture_get"/);
+ok(defined($picture_read),"picture-settings read: anchors still present");
+
+SKIP: {
+ skip "picture-settings read not locatable",4 if(!defined($picture_read));
+ my $code=code_only($picture_read,"perl");
+ unlike($code,$CEC_POWER,"picture-settings read is not short-circuited by a CEC power reading");
+
+ # Name-independent form of the same contract: this handler reaches the helper
+ # through exactly four early returns -- the PIN-pairing guard and the three
+ # "Connect the LG TV" guards. Any interposed gate adds a fifth, whatever it
+ # is called and whether or not it mentions CEC.
+ my $returns=()=($code=~/^\s*return\b/mg);
+ is($returns,4,"picture-settings read still has exactly its four pairing/connection guards");
+
+ # The regression this bound exists to prevent: /api/lg/picture-settings is on
+ # the general WebUI lane, which is one serialized worker, and lg_helper_run is
+ # a synchronous backtick. A powered-off panel drops SYNs rather than refusing,
+ # so an unbounded read parks that worker for ~20s per poll against a ~30s
+ # panel refresh. A healthy read answers in under a second.
+ my ($default)=($code=~/\$helper_timeout\s*=\s*(\d+)\s*if\(\s*\$helper_timeout\s*<=\s*0\s*\)/);
+ ok(defined($default),"picture-settings read applies a default helper timeout when the caller sends none");
+ cmp_ok($default||0,"<=",20,"that default keeps the serialized WebUI worker bounded");
+}
+
+# A helper timeout equal to the browser timeout is not genuinely bounded from
+# the caller's point of view: the outer fetch wins the race before the helper's
+# timeout response can traverse the daemon. Keep a small response margin.
+my @bounded_browser_reads=(
+ ["display-control refresh",$lg,qr/async function lgDisplayControlRefresh\(force\)/,qr/async function lgDisplayControlCommit\(key\)/],
+ ["AutoCal clip-control refresh",$webui,qr/async function meterAutoCalLoadClipControls\(\)/,qr/async function meterAutoCalWriteClipControl\(key,value,pictureMode\)/],
+);
+foreach my $case (@bounded_browser_reads) {
+ my ($name,$source,$start,$end)=@$case;
+ my $region=slice_between($source,$start,$end);
+ ok(defined($region),"$name: caller is locatable");
+ next if(!defined($region));
+ my ($helper)=($region=~/helper_timeout\s*:\s*(\d+)/);
+ my ($fetch)=($region=~/_timeoutMs\s*:\s*(\d+)/);
+ ok(defined($helper) && defined($fetch) && ($helper*1000)<$fetch,
+  "$name: helper deadline leaves time for the HTTP response");
+}
+
+#############################################################################
+# 3. lg_helper_timeout behaviour, executed rather than grepped.
+#
+# The sub is pure, so it can be lifted into a sandbox package and called. This
+# is the only part of this file that tests behaviour instead of text.
+#############################################################################
+
+my ($timeout_src)=($lg=~/(sub lg_helper_timeout \(\@\) \{.*?\n\})/s);
+ok(defined($timeout_src),"lg_helper_timeout source is extractable");
+
+SKIP: {
+ skip "lg_helper_timeout not extractable",5 if(!defined($timeout_src));
+ my $ok=eval "package PGenTimeoutSandbox; $timeout_src; 1";
+ ok($ok,"lg_helper_timeout evaluates in isolation") or diag($@);
+ skip "lg_helper_timeout did not compile",4 if(!$ok);
+
+ is(PGenTimeoutSandbox::lg_helper_timeout({action=>"picture_get"}),60,
+  "picture_get keeps its 60s budget for callers that do not bound themselves");
+ is(PGenTimeoutSandbox::lg_helper_timeout({action=>"picture_get",helper_timeout=>8}),8,
+  "an explicit helper_timeout overrides the per-action budget");
+ is(PGenTimeoutSandbox::lg_helper_timeout({action=>"3d_lut_upload"}),180,
+  "long-running panel writes keep their generous budgets");
+ is(PGenTimeoutSandbox::lg_helper_timeout({action=>"something_new"}),90,
+  "an unrecognised action falls back to the default budget");
+}
+
+#############################################################################
+# 4. The removed helpers are gone from the whole tree, not just three files.
+#
+# This is the one grep-shaped assertion with no rename escape hatch: paired
+# with t/00-compile.t, "this identifier appears nowhere" cannot be satisfied by
+# renaming, because a renamed caller of a deleted sub still has to compile.
+#############################################################################
+
+my @removed=qw(
+ lg_tv_off_gate
+ lg_tv_powered_off
+ lg_cec_power_state_cached
+ lg_calibration_run_active
+ LG_CEC_POWER_CACHE_FILE
+ LG_TV_OFF_GATE_MAX_AGE
+ verify_lg_tv_power_for_autocal
+ meterEnsureLgTvReadyForAutoCal
+);
+
+my %orphans=map { $_ => [] } @removed;
+scan_tree($root,"usr",sub {
+ my ($relative,$contents)=@_;
+ # Comments first, in both styles: this tree keeps its browser JS inside Perl
+ # strings, so a single file can carry either. A comment naming a helper that
+ # was removed is documentation, not a dangling caller, and must not fail.
+ my $code=code_only(code_only($contents,"perl"),"js");
+ foreach my $symbol (@removed) {
+  push(@{$orphans{$symbol}},$relative) if($code=~/\Q$symbol\E/);
+ }
+});
+
+foreach my $symbol (@removed) {
+ is(scalar(@{$orphans{$symbol}}),0,"$symbol has no remaining references under usr/")
+  or diag("still referenced in: ".join(", ",@{$orphans{$symbol}}));
+}
+
+#############################################################################
+# 5. CEC survives as an integration. Status display, explicit controls,
+#    discovery and HDMI input selection stay useful even though they no longer
+#    gate anything.
+#############################################################################
+
+like($webui,qr/sub webui_cec \(\@\)/,"CEC API remains available");
+like($webui,qr/async function cecCmd\(cmd\)/,"CEC controls remain available in the browser");
+like($lg,qr/sub lg_cec_status \(\@\)/,"LG status still exposes CEC information");
+like($lg,qr/tv_input\s*=>\s*&lg_input_from_cec\(\)/,"LG requests still use CEC-derived HDMI input information");
+
+done_testing();

--- a/t/full_autocal_replay_guard.t
+++ b/t/full_autocal_replay_guard.t
@@ -1,0 +1,93 @@
+#
+# Contract: one completed Full AutoCal run cannot launch its 3D stage twice.
+#
+# A replay is destructive even when the second upload fails: the start route
+# first stops the shared meter/series owner, which cancels a post-cal report.
+# The browser must therefore validate backend workflow metadata, and the
+# server must reject a same-run completion before it calls webui_meter_stop().
+#
+use strict;
+use warnings;
+use Test::More;
+use FindBin qw($Bin);
+use lib "$FindBin::Bin/lib";
+use PGenSource qw(repo_root slurp_source code_only slice_between);
+
+my $root=repo_root($Bin);
+my $webui=slurp_source($root,"usr/share/PGenerator/webui.pm");
+
+my ($state_match)=($webui=~/(sub webui_meter_lg_3d_autocal_completed_state_matches \(\@\) \{.*?^\})/ms);
+my ($report_match)=($webui=~/(sub webui_meter_lg_3d_autocal_completed_report_matches \(\@\) \{.*?^\})/ms);
+ok(defined($state_match),"completed worker-state predicate is extractable");
+ok(defined($report_match),"completed report predicate is extractable");
+
+SKIP: {
+ skip "completion predicates not extractable",7 if(!defined($state_match) || !defined($report_match));
+ my $ok=eval "package PGenReplaySandbox; $state_match\n$report_match\n1";
+ ok($ok,"completion predicates evaluate in isolation") or diag($@);
+ skip "completion predicates did not compile",6 if(!$ok);
+
+ ok(PGenReplaySandbox::webui_meter_lg_3d_autocal_completed_state_matches({
+   status=>'complete',upload_verified=>1,full_autocal_run_id=>'full-run-1'
+  },'full-run-1'),
+  "a verified terminal 3D state is a completion receipt");
+ ok(!PGenReplaySandbox::webui_meter_lg_3d_autocal_completed_state_matches({
+   status=>'error',upload_verified=>0,full_autocal_run_id=>'full-run-1'
+  },'full-run-1'),
+  "a failed upload remains retryable");
+ ok(!PGenReplaySandbox::webui_meter_lg_3d_autocal_completed_state_matches({
+   status=>'complete',upload_verified=>1,full_autocal_run_id=>'another-run'
+  },'full-run-1'),
+  "a different run's terminal state does not block this run");
+
+ my $complete_archive={run_id=>'full-run-1',report=>{run_id=>'full-run-1',completion_status=>{
+  status=>'complete',full_workflow=>1
+ }}};
+ ok(PGenReplaySandbox::webui_meter_lg_3d_autocal_completed_report_matches($complete_archive,'full-run-1'),
+  "the durable completed report is a completion receipt");
+ ok(!PGenReplaySandbox::webui_meter_lg_3d_autocal_completed_report_matches({
+   run_id=>'full-run-1',report=>{completion_status=>{status=>'running',full_workflow=>1}}
+  },'full-run-1'),
+  "an incomplete report does not block a legitimate stage start");
+ ok(!PGenReplaySandbox::webui_meter_lg_3d_autocal_completed_report_matches($complete_archive,'another-run'),
+  "a different run's report does not block this run");
+}
+
+my $start=slice_between(
+ $webui,
+ qr/sub webui_meter_lg_3d_autocal_start \(\@\) \{/,
+ qr/sub webui_meter_lg_3d_autocal_compact_status_json/
+);
+ok(defined($start),"3D start handler is locatable");
+SKIP: {
+ skip "3D start handler not locatable",2 if(!defined($start));
+ my $code=code_only($start,"perl");
+ my $guard=index($code,'webui_meter_lg_3d_autocal_full_run_already_complete($body)');
+ my $stop=index($code,'&webui_meter_stop();');
+ ok($guard>=0,"3D start handler invokes the completed-run guard");
+ ok($stop>=0 && $guard<$stop,"completed-run guard executes before destructive meter teardown");
+}
+
+like($webui,qr/"already_complete":true.*webui_meter_lg_3d_autocal_full_run_already_complete/s,
+ "server labels the idempotent rejection for stale-client cleanup");
+like($webui,qr/if\(r&&r\.already_complete\).*?return 'already-complete';/s,
+ "browser retires a rejected stale workflow without entering retry/abort");
+
+my $ensure=slice_between(
+ $webui,
+ qr/function meterFullAutoCalEnsureStatusPhase\(status,phase\)\{/,
+ qr/function meterFullAutoCalRestoreSavedState\(\)/
+);
+ok(defined($ensure),"browser phase-adoption helper is locatable");
+SKIP: {
+ skip "phase-adoption helper not locatable",3 if(!defined($ensure));
+ my $code=code_only($ensure,"js");
+ my $metadata=index($code,"if(!(status&&status.full_workflow&&meterFullAutoCalStatusPhase(status)===phase)) return false;");
+ my $trusted=index($code,"if(meterFullAutoCalRunning&&currentPhase===phase) return true;");
+ ok($metadata>=0,"browser requires backend workflow metadata");
+ ok($trusted>=0 && $metadata<$trusted,"backend metadata is checked before saved browser phase is trusted");
+ like($code,qr/currentPhase==='precal-report'\|\|currentPhase==='postcal-report'/,
+  "report phases cannot adopt a calibration-stage result");
+}
+
+done_testing();

--- a/t/lg_picture_mode_regression.t
+++ b/t/lg_picture_mode_regression.t
@@ -1,0 +1,10 @@
+use strict;
+use warnings;
+use FindBin qw($Bin);
+
+# Keep the PR's standalone hardware-free regression check in the normal test
+# suite as well, so future picture-mode changes cannot silently bypass it.
+my $script="$Bin/../tools/check_lg_picture_mode_regression.pl";
+my $result=do $script;
+die $@ if($@);
+die "could not run $script: $!" if(!defined($result));

--- a/t/lib/PGenSource.pm
+++ b/t/lib/PGenSource.pm
@@ -1,0 +1,122 @@
+package PGenSource;
+#
+# Shared helpers for the source-level contract tests in t/.
+#
+# These tests assert on source text because this project has no way to spin up
+# a WebOS session, a meter or a panel in a test. That is a real constraint, but
+# it is not a licence to write assertions that cannot fail. Two rules follow
+# from the first version of t/cec_autocal_contract.t, which passed with every
+# removed gate re-introduced under a new name and failed when someone added an
+# explanatory comment:
+#
+#   1. Assert on the CONTENTS of a region, never on "A appears before B".
+#      A /A.*?B/s pattern places no constraint on the gap -- and the gap is
+#      exactly where deleted code would come back.
+#   2. Strip comments before asserting on code. Documenting a removal must
+#      never break a test about behaviour.
+#
+use strict;
+use warnings;
+use File::Spec ();
+use File::Find ();
+
+use Exporter ();
+our @ISA=qw(Exporter);
+our @EXPORT_OK=qw(repo_root source_path slurp_source code_only slice_between code_lines_between scan_tree);
+
+sub repo_root {
+ my ($bin)=@_;
+ return File::Spec->rel2abs(File::Spec->catdir($bin,".."));
+}
+
+sub source_path {
+ my ($root,$relative)=@_;
+ return File::Spec->catfile($root,split(m{/},$relative));
+}
+
+sub slurp_source {
+ my ($root,$relative)=@_;
+ my $path=source_path($root,$relative);
+ open(my $fh,"<",$path) or die "read $relative: $!";
+ local $/;
+ my $source=<$fh>;
+ close($fh);
+ return $source;
+}
+
+# Remove comments so an assertion about code cannot be tripped by prose.
+# Perl: full-line comments only -- a trailing "#" is too easily inside a string
+# or a regex to strip safely, and full-line is what documentation uses.
+# JS: "//" to end of line, but not the "//" in a URL, plus /* ... */ blocks.
+sub code_only {
+ my ($text,$style)=@_;
+ return "" if(!defined($text));
+ $style="perl" if(!defined($style));
+ if($style eq "perl") {
+  $text=~s{^[ \t]*\#.*$}{}mg;
+ } else {
+  $text=~s{/\*.*?\*/}{}gs;
+  $text=~s{(?<!:)//[^\n]*}{}g;
+ }
+ return $text;
+}
+
+# Return the text lying strictly between the end of $start_re and the start of
+# the next $end_re after it. Returns undef if either anchor is missing, so a
+# renamed anchor surfaces as a failed test rather than a silently empty slice.
+sub slice_between {
+ my ($source,$start_re,$end_re)=@_;
+ return undef if($source !~ /$start_re/);
+ my $from=$+[0];
+ my $rest=substr($source,$from);
+ return undef if($rest !~ /$end_re/);
+ return substr($rest,0,$-[0]);
+}
+
+# Return the executable lines lying strictly between the line matching
+# $start_re and the next line matching $end_re, comment-stripped, trimmed and
+# with blanks dropped. Slicing by line rather than by character offset keeps
+# the anchors themselves out of the result, so callers can compare what is
+# left against an exact expected sequence -- which is what makes an inserted
+# statement fail no matter what it is called.
+sub code_lines_between {
+ my ($source,$start_re,$end_re,$style)=@_;
+ my @lines=split(/\n/,$source,-1);
+ my ($start,$end);
+ for(my $i=0;$i<@lines;$i++) {
+  if(!defined($start)) { $start=$i if($lines[$i]=~/$start_re/); next; }
+  if($lines[$i]=~/$end_re/) { $end=$i; last; }
+ }
+ return undef if(!defined($start) || !defined($end));
+ my $body=join("\n",@lines[$start+1..$end-1]);
+ return [grep { /\S/ } map { my $l=$_; $l=~s/^\s+//; $l=~s/\s+$//; $l } split(/\n/,code_only($body,$style),-1)];
+}
+
+# Walk a subtree and hand every readable text file to $callback as
+# ($repo_relative_path, $contents). Binary blobs and oversized files are
+# skipped -- usr/share/PGenerator/icc-companion holds .so/.dll/.exe payloads.
+sub scan_tree {
+ my ($root,$subdir,$callback)=@_;
+ my $base=File::Spec->catdir($root,split(m{/},$subdir));
+ return if(!-d $base);
+ File::Find::find({
+  no_chdir => 1,
+  wanted   => sub {
+   my $path=$File::Find::name;
+   return if(!-f $path);
+   return if(-s $path > 5_000_000);
+   open(my $fh,"<",$path) or return;
+   binmode($fh);
+   local $/;
+   my $contents=<$fh>;
+   close($fh);
+   return if(!defined($contents));
+   return if($contents=~/\0/);
+   my $relative=File::Spec->abs2rel($path,$root);
+   $relative=~s{\\}{/}g;
+   $callback->($relative,$contents);
+  },
+ },$base);
+}
+
+1;

--- a/tools/check_lg_picture_mode_regression.pl
+++ b/tools/check_lg_picture_mode_regression.pl
@@ -1,0 +1,345 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+no warnings 'once'; # The isolated workflow harness intentionally uses package globals.
+use FindBin;
+use Test::More;
+
+my $path="$FindBin::Bin/../usr/sbin/pgenerator-lg";
+open(my $fh,'<',$path) or die "open $path: $!";
+my $source=do { local $/; <$fh> };
+close($fh);
+
+# Extraction relies on the file's convention that only a sub's own closing
+# brace sits in column 0. BAIL_OUT on a miss so a failed extraction reads as
+# "the source changed shape", not as a confusing runtime die further down.
+sub extract_sub {
+ my $name=shift;
+ my ($sub)=$source=~/(sub \Q$name\E \(\@\) \{.*?^\})/ms;
+ ok($sub,"$name is present") or BAIL_OUT("could not extract sub $name from $path");
+ return $sub;
+}
+
+# --- lg_picture_mode_ssap_payload -------------------------------------------
+
+{
+ my $payload_sub=extract_sub('lg_picture_mode_ssap_payload');
+ package LGPictureModePayloadTest;
+ eval "$payload_sub\n1;" or die $@;
+}
+
+is_deeply(
+ LGPictureModePayloadTest::lg_picture_mode_ssap_payload('filmMaker'),
+ {
+  category => 'picture',
+  settings => { pictureMode => 'filmMaker' },
+ },
+ 'picture-mode selection uses the minimal public WebOS settings payload',
+);
+is_deeply(
+ LGPictureModePayloadTest::lg_picture_mode_ssap_payload(undef),
+ {
+  category => 'picture',
+  settings => { pictureMode => '' },
+ },
+ 'an undefined picture mode degrades to an empty payload value instead of dying',
+);
+
+# --- lg_picture_mode_readback_matches ---------------------------------------
+
+{
+ my $code=join("\n",
+  extract_sub('lg_picture_mode_readback_canonical'),
+  extract_sub('lg_picture_mode_readback_matches'));
+ package LGPictureModeReadbackTest;
+ eval "$code\n1;" or die $@;
+}
+
+sub readback_matches { return LGPictureModeReadbackTest::lg_picture_mode_readback_matches(@_); }
+
+ok(readback_matches('filmMaker','filmMaker'),
+ 'matching picture-mode readback is accepted');
+ok(!readback_matches('filmMaker','cinema'),
+ 'stale picture-mode readback is rejected');
+ok(readback_matches('dolbyHdrCinema','dolbyHdrCinemaDark'),
+ 'the C1/C2 Dolby Vision readback-only label matches its write value');
+ok(readback_matches('dolbyHdrCinema','dolby_hdr_cinema_dark'),
+ 'the C1 separator-form Dolby Vision readback matches its write value');
+ok(readback_matches('dolbyHdrCinemaDark','dolbyHdrCinema'),
+ 'Dolby Vision readback equivalence holds in both directions');
+ok(!readback_matches('dolbyHdrCinema','dolbyHdrCinemaBright'),
+ 'Dolby Vision Cinema and Cinema Bright remain distinct');
+ok(readback_matches('game','gameOptimizer'),
+ 'the Game Optimizer readback label matches the game enum');
+ok(!readback_matches('standard','aps'),
+ 'Energy Saving (aps) readback does not verify a standard request');
+ok(!readback_matches('standard','eco'),
+ 'Eco readback does not verify a standard request');
+ok(!readback_matches('vivid','sports'),
+ 'Sports readback does not verify a vivid request');
+ok(!readback_matches('cinema','cinemaHome'),
+ 'Cinema Home readback does not verify a cinema request');
+ok(readback_matches('FILMMAKER','filmMaker'),
+ 'case differences in enum names are tolerated');
+ok(readback_matches('hdrFilmMaker','hdr_filmmaker'),
+ 'separator differences in enum names are tolerated');
+ok(!readback_matches('hdrCinema','hdrStandard'),
+ 'different HDR modes are rejected');
+ok(readback_matches('unknownMode','unknownMode'),
+ 'identical unmapped mode names still verify');
+ok(!readback_matches('unknownModeA','unknownModeB'),
+ 'different unmapped mode names are rejected');
+ok(!readback_matches('filmMaker',''),
+ 'an empty readback value is never treated as verified');
+ok(!readback_matches('filmMaker',undef),
+ 'an undefined readback value is never treated as verified');
+ok(!readback_matches('','cinema'),
+ 'an empty requested mode is never treated as verified');
+
+# --- lg_picture_set_workflow: source-shape checks ---------------------------
+
+my $workflow=extract_sub('lg_picture_set_workflow');
+like(
+ $workflow,
+ qr/"settings\/setSystemSettings",\s*\$set_payload/s,
+ 'picture-mode write uses public SSAP setSystemSettings',
+);
+unlike(
+ $workflow,
+ qr/set_picture_mode_active_app/,
+ 'the current_app-scoped Luna alert write path is not reintroduced',
+);
+like(
+ $workflow,
+ qr/if\(\$picture_mode_readback_supported\).*?push\(\@\{\$readback_keys\},"pictureMode"\)/s,
+ 'readable picture-mode requests gain a pictureMode readback key',
+);
+like(
+ $workflow,
+ qr/\$generation->\{"picture_mode_read_forbidden"\}.*?\$picture_mode_readback_required/s,
+ 'generation metadata prevents mandatory readback on read-forbidden sets',
+);
+like(
+ $workflow,
+ qr/get_picture_mode_after_.*?settings\/getSystemSettings/s,
+ 'picture-mode selection performs a separate readback poll',
+);
+like(
+ $workflow,
+ qr/if\(&lg_picture_mode_readback_matches\(\$active_picture_mode,\$observed_picture_mode\)\)/,
+ 'the poll verifies the observed mode through the readback matcher',
+);
+like(
+ $workflow,
+ qr/if\(\$picture_mode_readback_required && !\$picture_mode_readback_verified\) \{.*?picture-mode-readback-mismatch/s,
+ 'an unverified picture-mode readback is reported as failure',
+);
+
+# PR #30 predates the C1 Dolby Vision 3D LUT routing fix on the test branch.
+# Keep that later behaviour pinned while integrating its picture-mode path.
+my $lut_resolver=extract_sub('lg_3d_lut_resolve_mode');
+like(
+ $lut_resolver,
+ qr/lg_resolve_ddc_picture_mode\(\$ip,\$picture_mode,\$signal_mode\)/,
+ '3D LUT DDC resolution still receives the active signal mode',
+);
+like(
+ $lut_resolver,
+ qr/generation_id.*?lg2021_oled.*?\$signal_mode.*?dv.*?dolbyVisionFilmMaker/s,
+ 'C1 Dolby Vision 3D LUT routing still targets the hardware-proven dark mode',
+);
+
+# --- lg_picture_set_workflow: behavioural harness ---------------------------
+# Run the real workflow sub with the real mapper/matcher and stubbed TV I/O.
+# The stubs mirror the response shapes of the real helpers (json_ok,
+# json_error, response_is_app_failure) closely enough to drive every branch
+# under test without a TV.
+
+{
+ my $helpers=join("\n",map { extract_sub($_) } qw(
+  map_picture_mode_label_to_ddc_name
+  lg_picture_mode_signal_for_canonical_name
+  lg_picture_mode_signal_compatible
+  lg_picture_mode_signal_examples
+  lg_picture_mode_ssap_payload
+  lg_picture_mode_readback_canonical
+  lg_picture_mode_readback_matches
+ ));
+my $stubs=<<'STUBS';
+our (@READBACK_MODES,@PALM_MODES,@REQUEST_LABELS,@LUNA_LABELS,$SET_RESPONSE,$LUNA_RESPONSE,$GENERATION);
+$WRITABLE_PICTURE_MODES_RE=qr/^(?:expert|cinema|filmmaker|game|standard)/;
+sub lg_authenticated_session { return { status => "ok", session => {}, client_key => "test-key", hello_info => {}, system_info => {}, software_info => {} }; }
+sub lg_generation_info { return $GENERATION||{}; }
+sub lg_ddc_has_22pt_rgb { return 0; }
+sub lg_picture_mode_for_calibration { return ""; }
+sub lg_ddc_1d_target_info { return {}; }
+sub lg_ddc_1d_nonzero_map { return {}; }
+sub lg_palm_picture_setting { return @PALM_MODES ? shift(@PALM_MODES) : ""; }
+sub lg_current_picture_mode { return ""; }
+sub lg_ddc_virtual_picture_settings { return {}; }
+sub diag_log_append { return; }
+sub websocket_close { return; }
+sub json_true { return 1; }
+sub json_false { return 0; }
+sub json_bool { return $_[0] ? 1 : 0; }
+sub json_error {
+ my ($message,$extra)=@_;
+ $extra={} if(ref($extra) ne "HASH");
+ $extra->{"status"}="error";
+ $extra->{"message"}=$message;
+ return $extra;
+}
+sub json_ok {
+ my $extra=shift;
+ $extra={} if(ref($extra) ne "HASH");
+ $extra->{"status"}="ok";
+ return $extra;
+}
+sub json_permission_error {
+ my ($message,$extra)=@_;
+ $extra=&json_error($message,$extra);
+ $extra->{"error_code"}="insufficient-permissions";
+ return $extra;
+}
+sub response_is_app_failure {
+ my $response=shift;
+ return (0,"") if(ref($response) ne "HASH");
+ return (1,$response->{"error"}||"error envelope") if(($response->{"type"}||"") eq "error");
+ my $payload=(ref($response->{"payload"}) eq "HASH") ? $response->{"payload"} : {};
+ return (1,"returnValue false") if(defined($payload->{"returnValue"}) && !$payload->{"returnValue"});
+ return (0,"");
+}
+sub lg_request {
+ my ($session,$label,$path,$payload,$timeout)=@_;
+ push(@REQUEST_LABELS,$label);
+ return $SET_RESPONSE if($label eq "set_picture_mode");
+ if($label =~ /^get_picture_mode_after_/) {
+  return undef if(!@READBACK_MODES);
+  my $mode=shift(@READBACK_MODES);
+  return { type => "response", payload => { returnValue => 1, settings => { pictureMode => $mode } } };
+ }
+ return { type => "response", payload => { returnValue => 1, settings => {} } };
+}
+sub lg_luna_request {
+ my ($session,$label,$path,$payload,$timeout)=@_;
+ push(@LUNA_LABELS,$label);
+ return $LUNA_RESPONSE;
+}
+STUBS
+ package LGWorkflowRunTest;
+ eval "no strict;\nno warnings;\n$stubs\n$helpers\n$workflow\n1;" or die $@;
+}
+
+sub run_picture_mode_workflow {
+ my (%opt)=@_;
+ @LGWorkflowRunTest::READBACK_MODES=@{$opt{readback_modes}||[]};
+ @LGWorkflowRunTest::PALM_MODES=@{$opt{palm_modes}||[]};
+ @LGWorkflowRunTest::REQUEST_LABELS=();
+ @LGWorkflowRunTest::LUNA_LABELS=();
+ $LGWorkflowRunTest::GENERATION=$opt{generation}||{
+  generation_id => "lg2022plus_oled",
+  ddc_only_white_balance => 0,
+  picture_mode_read_forbidden => 0,
+ };
+ $LGWorkflowRunTest::SET_RESPONSE=$opt{set_response}
+  || { type => "response", payload => { returnValue => 1 } };
+ $LGWorkflowRunTest::LUNA_RESPONSE=$opt{luna_response}
+  || { type => "response", payload => { returnValue => 1 } };
+ return LGWorkflowRunTest::lg_picture_set_workflow(
+  "192.0.2.10","test-key",1,
+  { pictureMode => $opt{request_mode} },
+  [],"hdmi2",0,"",0,0,0,0,$opt{signal_mode}||"sdr");
+}
+
+# Scenario 1: readback matches on the first poll attempt.
+{
+ my $result=run_picture_mode_workflow(request_mode => "filmMaker", readback_modes => ["filmMaker"]);
+ is($result->{status},'ok','verified first readback reports success');
+ ok($result->{picture_mode_readback_verified},'success payload marks the readback verified');
+ is($result->{picture_mode_readback_attempts},1,'success payload counts one readback attempt');
+ is($result->{picture_mode_write_path},'ssap://settings/setSystemSettings',
+  'verified public write reports its actual SSAP transport');
+ is($result->{picture_settings}{pictureMode},'filmMaker','success payload carries the observed mode');
+ is(scalar(grep { $_ eq 'set_picture_mode' } @LGWorkflowRunTest::REQUEST_LABELS),1,
+  'exactly one SSAP picture-mode write was sent');
+}
+
+# Scenario 2: TV needs several polls before the mode lands.
+{
+ my $result=run_picture_mode_workflow(request_mode => "filmMaker",
+  readback_modes => ["cinema","cinema","cinema","filmMaker"]);
+ is($result->{status},'ok','late-arriving readback still reports success');
+ is($result->{picture_mode_readback_attempts},4,'poll kept reading until the mode was observed');
+}
+
+# Scenario 3: TV acknowledges the write but stays on the previous mode.
+{
+ my $result=run_picture_mode_workflow(request_mode => "filmMaker",
+  readback_modes => [("cinema") x 10]);
+ is($result->{status},'error','stale readback reports failure, not success');
+ is($result->{error_code},'picture-mode-readback-mismatch','stale readback carries the mismatch error code');
+ is($result->{observed_picture_mode},'cinema','the mode the TV actually reported is surfaced');
+ like($result->{message},qr/remained on 'cinema'/,'failure message names the stale mode');
+}
+
+# Scenario 4: TV never returns a usable readback at all.
+{
+ my $result=run_picture_mode_workflow(request_mode => "filmMaker", readback_modes => []);
+ is($result->{status},'error','missing readback reports failure, not success');
+ is($result->{error_code},'picture-mode-readback-mismatch','missing readback carries the mismatch error code');
+ is($result->{observed_picture_mode},'','no observed mode is reported when the TV never answered');
+}
+
+# Scenario 5: SSAP write is refused for permissions; the Luna fallback applies
+# the mode and the readback poll still decides success.
+{
+ my $result=run_picture_mode_workflow(request_mode => "filmMaker",
+  set_response => { type => "error", error => "401 insufficient permissions" },
+  readback_modes => ["filmMaker"]);
+ is($result->{status},'ok','permission-refused SSAP write recovers through the Luna fallback');
+ ok($result->{picture_mode_readback_verified},'the Luna fallback result is still readback-verified');
+ is($result->{picture_mode_write_path},'luna://com.webos.settingsservice/setSystemSettings',
+  'permission fallback reports its actual Luna transport');
+ is(scalar(grep { $_ eq 'set_picture_settings_luna' } @LGWorkflowRunTest::LUNA_LABELS),1,
+  'the Luna fallback write path was used exactly once');
+}
+
+# Scenario 6: C1/B1/G1/Z1 do not expose public pictureMode readback. An
+# accepted bridge write must therefore retain the established unverifiable
+# success behaviour rather than being turned into a false failure.
+{
+ my $result=run_picture_mode_workflow(
+  request_mode => "filmMaker",
+  generation => {
+   generation_id => "lg2021_oled",
+   ddc_only_white_balance => 1,
+   picture_mode_read_forbidden => 1,
+  },
+ );
+ is($result->{status},'ok','read-forbidden C1 bridge write remains successful');
+ ok(!$result->{picture_mode_verified},'empty C1 readback is explicitly unverifiable');
+ is(scalar(grep { $_ eq 'set_picture_mode' } @LGWorkflowRunTest::REQUEST_LABELS),0,
+  'read-forbidden C1 does not use the public SSAP picture-mode write');
+ is(scalar(grep { $_ eq 'set_picture_mode_palm-bridge' } @LGWorkflowRunTest::LUNA_LABELS),1,
+  'read-forbidden C1 uses its established bridge transport once');
+}
+
+# Scenario 7: a C1 may report the dark Dolby Vision mode using its
+# separator-form readback enum. It is a verified match, not a separate mode.
+{
+ my $result=run_picture_mode_workflow(
+  request_mode => "dolbyVisionFilmMaker",
+  signal_mode => "dv",
+  palm_modes => ["","dolby_hdr_cinema_dark"],
+  generation => {
+   generation_id => "lg2021_oled",
+   ddc_only_white_balance => 1,
+   picture_mode_read_forbidden => 1,
+  },
+ );
+ is($result->{status},'ok','C1 separator-form Dolby Vision readback reports success');
+ is($result->{active_picture_mode},'dolbyHdrCinema','C1 dark Dolby Vision request uses the accepted WebOS write enum');
+ ok($result->{picture_mode_verified},'C1 separator-form Dolby Vision readback is verified');
+}
+
+done_testing();

--- a/usr/bin/meter_lg_3d_autocal.pl
+++ b/usr/bin/meter_lg_3d_autocal.pl
@@ -10,6 +10,9 @@ use JSON::PP ();
 use MIME::Base64 ();
 use POSIX qw(strftime WNOHANG);
 use Time::HiRes qw(sleep time);
+use FindBin qw($Bin);
+use lib "$Bin/../share/PGenerator";
+use PGAutoCalSafety qw(profile_reading_plausibility_error profile_primary_monotonicity_error);
 
 our $PGAC_LOADED = 0;
 eval { require '/usr/share/PGenerator/PGAutoCalRun.pm'; $PGAC_LOADED = 1; 1 };
@@ -1163,7 +1166,7 @@ sub capture_volume_drift_anchor {
   $state->{"current_name"}=($label||"Drift anchor")." ".uc(substr($kind,0,1));
   $state->{"message"}="WRGB drift re-anchor - reading ".$kind;
   write_state($state);
-  my ($reading,$error)=read_step($config,$step,$state);
+  my ($reading,$error)=read_validated_profile_step($config,$step,$state,undef);
   die "Drift anchor $kind failed: $error\n" if($error);
   my $xyz=reading_xyz($reading);
   die "Drift anchor $kind returned no XYZ\n" if(!$xyz);
@@ -3051,6 +3054,49 @@ sub read_step {
  return (undef,$last||"Meter read failed");
 }
 
+# Profile measurements are solver inputs, not ordinary chart samples.  Retry
+# impossible values here so a stale black result can never become a valid
+# colour-model endpoint merely because the meter request itself succeeded.
+sub read_validated_profile_step {
+ my ($config,$step,$state,$previous_entries)=@_;
+ my $attempts=3;
+ my $last="";
+ for(my $attempt=1;$attempt<=$attempts;$attempt++) {
+  my ($reading,$error)=read_step($config,$step,$state);
+  return (undef,$error) if($error);
+  my $reason=profile_reading_plausibility_error($step,$reading);
+  $reason=profile_primary_monotonicity_error($step,$reading,$previous_entries) if(!defined($reason));
+  if(!defined($reason)) {
+   if($attempt > 1 && ref($state) eq "HASH") {
+    $state->{profile_validation_recoveries}=($state->{profile_validation_recoveries}||0)+1;
+    write_state($state);
+   }
+   return ($reading,undef);
+  }
+  $last=$reason;
+  my $name=$step->{name}||"profile patch";
+  log_line("Rejected implausible profile reading for $name ($attempt/$attempts): $reason");
+  if(ref($state) eq "HASH") {
+   $state->{profile_validation_failures}=[] if(ref($state->{profile_validation_failures}) ne "ARRAY");
+   push @{$state->{profile_validation_failures}},{
+    name=>$name,
+    attempt=>$attempt+0,
+    reason=>$reason,
+    X=>defined($reading->{X}) ? ($reading->{X}+0) : undef,
+    Y=>defined($reading->{Y}) ? ($reading->{Y}+0) : undef,
+    Z=>defined($reading->{Z}) ? ($reading->{Z}+0) : undef,
+    r_code=>defined($step->{r}) ? ($step->{r}+0) : undef,
+    g_code=>defined($step->{g}) ? ($step->{g}+0) : undef,
+    b_code=>defined($step->{b}) ? ($step->{b}+0) : undef,
+   };
+   $state->{message}="Rejected implausible $name reading; retrying ($attempt/$attempts)";
+   write_state($state);
+  }
+  sleep(1+$attempt) if($attempt < $attempts);
+ }
+ return (undef,"Invalid profile reading for ".($step->{name}||"patch")." after $attempts attempts: $last");
+}
+
 sub post_check_steps {
 	 my ($config)=@_;
 	 my @steps;
@@ -4568,7 +4614,7 @@ eval {
   $state->{"profile_total"}=$profile_total;
   $state->{"message"}=($method eq "matrix" ? "Matrix profile " : "3D LUT profile ").($i+1)."/".$profile_total." - Reading ".($step->{"name"}||"patch");
   write_state($state);
-  my ($reading,$error)=read_step($config,$step,$state);
+  my ($reading,$error)=read_validated_profile_step($config,$step,$state,\@profile_readings);
   die "$error\n" if($error);
   my $entry={ step=>$step, reading=>$reading, read_time=>time() };
   push @profile_readings,$entry if(($step->{"phase"}||"") ne "post_check");
@@ -4990,6 +5036,20 @@ eval {
     log_line("HDR20 shadow-after re-commit MISMATCH: 3D LUT failed (".$sl_detail->{message}.") but tone map ok — manual 3D LUT re-upload needed");
    } else {
     $state->{"postcal_shadow_recommit_mismatch"}=JSON::PP::false;
+   }
+   # A failed attempt to rebuild the held calibration session is recoverable:
+   # this explicit final LUT + tone-map re-commit establishes the same panel
+   # state through the normal verified upload path.  Do not leave the terminal
+   # status carrying the earlier "will likely fail" note after both uploads
+   # have demonstrably succeeded.
+   if($sl_status eq "ok" && $st_status eq "ok" && ref($state->{"hdr20_postcal_shadow"}) eq "HASH") {
+    $state->{"hdr20_postcal_shadow"}->{"reestablished"}=JSON::PP::true;
+    $state->{"hdr20_postcal_shadow"}->{"final_recommit_verified"}=JSON::PP::true;
+    my $_shadow_note=$state->{"hdr20_postcal_shadow"}->{"note"}||"";
+    $_shadow_note=~s/re-establish reported failure; 3D profiling will likely fail\.//g;
+    $_shadow_note=~s/^\s+|\s+$//g;
+    $state->{"hdr20_postcal_shadow"}->{"note"}=$_shadow_note;
+    $state->{"postcal_shadow_final_recommit_verified"}=JSON::PP::true;
    }
    write_state($state);
    1;

--- a/usr/bin/meter_lg_3d_autocal.pl
+++ b/usr/bin/meter_lg_3d_autocal.pl
@@ -8,7 +8,7 @@ use IO::Select ();
 use IO::Socket::INET ();
 use JSON::PP ();
 use MIME::Base64 ();
-use POSIX qw(strftime);
+use POSIX qw(strftime WNOHANG);
 use Time::HiRes qw(sleep time);
 
 our $PGAC_LOADED = 0;
@@ -149,6 +149,20 @@ sub write_state {
   $encoded=$json->encode(\%fallback);
  };
  return write_file($state_file,$encoded,0);
+}
+
+sub set_lut_calculation_progress {
+ my ($state,$stage,$current,$total,$active)=@_;
+ return if(ref($state) ne "HASH");
+ $current=int($current||0);
+ $total=int($total||0);
+ $current=0 if($current < 0);
+ $current=$total if($total > 0 && $current > $total);
+ $state->{"lut_calculation_active"}=json_bool($active);
+ $state->{"lut_calculation_stage"}=$stage||"3D LUT calculation";
+ $state->{"lut_calculation_current_nodes"}=$current;
+ $state->{"lut_calculation_total_nodes"}=$total;
+ write_state($state);
 }
 
 sub cancelled {
@@ -1751,11 +1765,12 @@ sub node_output_pct {
 }
 
 sub _generate_lut_cube_serial {
- my ($model,$size)=@_;
+ my ($model,$size,$progress_cb)=@_;
  $size ||= 17;
  my @nodes;
  my @u16;
  for(my $r=0;$r<$size;$r++) {
+  die "cancelled\n" if(cancelled());
   for(my $g=0;$g<$size;$g++) {
    for(my $b=0;$b<$size;$b++) {
     my $out=node_output_pct($model,$r,$g,$b,$size);
@@ -1764,6 +1779,7 @@ sub _generate_lut_cube_serial {
     push @nodes,{ in=>[$r,$g,$b], out_pct=>$out, out_12bit=>\@v } if(@nodes < 16 || ($r==$size-1 && $g==$size-1 && $b==$size-1));
    }
   }
+  $progress_cb->(($r+1)*$size*$size,$size**3) if(ref($progress_cb) eq "CODE");
  }
  return (\@u16,\@nodes);
 }
@@ -1795,10 +1811,11 @@ sub neutral_identity_output {
 }
 
 sub _generate_lut_lg_payload_serial {
- my ($model,$size)=@_;
+ my ($model,$size,$progress_cb)=@_;
  $size ||= 33;
  my @u16;
  for(my $b=0;$b<$size;$b++) {
+  die "cancelled\n" if(cancelled());
   for(my $g=0;$g<$size;$g++) {
    for(my $r=0;$r<$size;$r++) {
     my $out=node_output_pct($model,$r,$g,$b,$size);
@@ -1806,6 +1823,7 @@ sub _generate_lut_lg_payload_serial {
     push @u16,@v;
    }
   }
+  $progress_cb->(($b+1)*$size*$size,$size**3) if(ref($progress_cb) eq "CODE");
  }
  return \@u16;
 }
@@ -1834,58 +1852,115 @@ sub _lut_node_u16 {
  return map { int(clamp($_,0,100)*4095/100+0.5) } @{$out};
 }
 
+# Parallel LUT generation reports completed outer-axis slabs through one tiny
+# progress file per child. The parent remains the sole writer of the public
+# JSON state, avoiding child races while still exposing real node counts.
+# On cancellation the parent SIGKILLs the children (their compute loops never
+# check the flag) and returns failure; callers die "cancelled" after cleanup.
+sub _lut_wait_workers {
+ my ($jobs,$tmpdir,$plane_nodes,$total_nodes,$progress_cb)=@_;
+ my %pending=map { $_->[1] => $_ } @{$jobs};
+ my %completed;
+ my $last_total=0;
+ my $ok=1;
+ while(%pending) {
+  if(cancelled()) {
+   kill('KILL',keys %pending);
+   waitpid($_,0) foreach(keys %pending);
+   return 0;
+  }
+  foreach my $pid (keys %pending) {
+   my $job=$pending{$pid};
+   my ($w,$slabs)=($job->[0],$job->[2]);
+   my $raw=read_file("$tmpdir/w$w.progress");
+   $completed{$w}=int($1) if($raw =~ /^\s*(\d+)\s*$/);
+   my $result=waitpid($pid,WNOHANG);
+   if($result==$pid) {
+    my $exit_status=$?;
+    $ok=0 if(($exit_status >> 8) != 0 || ($exit_status & 127) != 0);
+    $completed{$w}=$slabs*$plane_nodes if(($exit_status >> 8) == 0 && ($exit_status & 127) == 0);
+    delete($pending{$pid});
+   } elsif($result < 0) {
+    $ok=0;
+    delete($pending{$pid});
+   }
+  }
+  my $done=0;
+  $done+=$_ foreach(values %completed);
+  $done=$total_nodes if($done > $total_nodes);
+  if($done != $last_total) {
+   $progress_cb->($done,$total_nodes) if(ref($progress_cb) eq "CODE");
+   $last_total=$done;
+  }
+  sleep(0.08) if(%pending);
+ }
+ return $ok;
+}
+
 sub generate_lut_cube {
- my ($model,$size)=@_;
+ my ($model,$size,$progress_cb)=@_;
  $size ||= 17;
  my $workers=_lut_gen_workers($size);
- return _generate_lut_cube_serial($model,$size) if($workers <= 1);
+ return _generate_lut_cube_serial($model,$size,$progress_cb) if($workers <= 1);
  my $tmpdir=sprintf("/tmp/lutcube_%d_%d", $$, time());
  if(!mkdir($tmpdir,0700)) {
   log_line("lut generate: mkdir $tmpdir failed ($!), serial cube");
-  return _generate_lut_cube_serial($model,$size);
+  return _generate_lut_cube_serial($model,$size,$progress_cb);
  }
  my $per=int(($size+$workers-1)/$workers);
  my @pids;
+ my $expected_workers=0;
  for(my $w=0;$w<$workers;$w++) {
   my $r0=$w*$per; my $r1=$r0+$per; $r1=$size if($r1 > $size);
   next if($r0 >= $size);
+  $expected_workers++;
   my $pid=fork();
   if(!defined $pid) { log_line("lut generate: fork failed on cube worker $w"); last; }
   if($pid == 0) {
-   my @u16;
-   for(my $r=$r0;$r<$r1;$r++) {
-    for(my $g=0;$g<$size;$g++) {
-     for(my $b=0;$b<$size;$b++) {
-      push @u16,_lut_node_u16($model,$r,$g,$b,$size);
+   $SIG{TERM}='DEFAULT'; $SIG{INT}='DEFAULT';
+   # A die here would unwind into the parent's top-level eval inside the
+   # child's copy of the script (state writes, upload paths) — never escape.
+   eval {
+    my @u16;
+    my $slabs_done=0;
+    for(my $r=$r0;$r<$r1;$r++) {
+     for(my $g=0;$g<$size;$g++) {
+      for(my $b=0;$b<$size;$b++) {
+       push @u16,_lut_node_u16($model,$r,$g,$b,$size);
+      }
      }
+     $slabs_done++;
+     write_file("$tmpdir/w$w.progress",$slabs_done*$size*$size,0);
     }
-   }
-   if(open(my $fh,'>',"$tmpdir/w$w.raw")) { binmode($fh); print $fh pack('S*',@u16); close($fh); }
+    if(open(my $fh,'>',"$tmpdir/w$w.raw")) { binmode($fh); print $fh pack('S*',@u16); close($fh); }
+    1;
+   } or exit 1;
    exit 0;
   }
-  push @pids,[$w,$pid];
+  push @pids,[$w,$pid,$r1-$r0];
  }
- my $ok=1;
- foreach my $job (@pids) {
-  my $cpid=waitpid($job->[1],0);
-  $ok=0 if($cpid < 0 || ($? >> 8) != 0);
- }
+ my $ok=(scalar(@pids)==$expected_workers) ? 1 : 0;
+ kill('KILL',map { $_->[1] } @pids) if(!$ok && @pids);
+ $ok=0 if(!_lut_wait_workers(\@pids,$tmpdir,$size*$size,$size**3,$progress_cb));
  my @u16;
- if($ok) {
-  for(my $w=0;$w<$workers;$w++) {
-   my $path="$tmpdir/w$w.raw";
-   next unless(-f $path);
+ for(my $w=0;$w<$workers;$w++) {
+  my $path="$tmpdir/w$w.raw";
+  if($ok && -f $path) {
    if(open(my $fh,'<',$path)) {
     binmode($fh); local $/; my $blob=<$fh>; close($fh);
     push @u16, unpack('S*',$blob) if(defined $blob && length($blob));
    }
-   unlink($path);
   }
+  unlink($path);
+  unlink("$tmpdir/w$w.progress");
+  unlink("$tmpdir/w$w.progress.tmp");
  }
  rmdir($tmpdir);
  if(!$ok || scalar(@u16) != 3*$size*$size*$size) {
+  die "cancelled\n" if(cancelled());
   log_line("lut generate: parallel cube failed (ok=$ok n=".scalar(@u16)."), serial fallback");
-  return _generate_lut_cube_serial($model,$size);
+  $progress_cb->(0,$size**3) if(ref($progress_cb) eq "CODE");
+  return _generate_lut_cube_serial($model,$size,$progress_cb);
  }
  log_line("lut generate: cube ${size}^3 via $workers workers");
  # Preview corners only — payload/export do not depend on these nodes.
@@ -1900,57 +1975,69 @@ sub generate_lut_cube {
 }
 
 sub generate_lut_lg_payload {
- my ($model,$size)=@_;
+ my ($model,$size,$progress_cb)=@_;
  $size ||= 33;
  my $workers=_lut_gen_workers($size);
- return _generate_lut_lg_payload_serial($model,$size) if($workers <= 1);
+ return _generate_lut_lg_payload_serial($model,$size,$progress_cb) if($workers <= 1);
  my $tmpdir=sprintf("/tmp/lutpay_%d_%d", $$, time());
  if(!mkdir($tmpdir,0700)) {
   log_line("lut generate: mkdir $tmpdir failed ($!), serial payload");
-  return _generate_lut_lg_payload_serial($model,$size);
+  return _generate_lut_lg_payload_serial($model,$size,$progress_cb);
  }
  my $per=int(($size+$workers-1)/$workers);
  my @pids;
+ my $expected_workers=0;
  for(my $w=0;$w<$workers;$w++) {
   my $b0=$w*$per; my $b1=$b0+$per; $b1=$size if($b1 > $size);
   next if($b0 >= $size);
+  $expected_workers++;
   my $pid=fork();
   if(!defined $pid) { log_line("lut generate: fork failed on payload worker $w"); last; }
   if($pid == 0) {
-   my @u16;
-   for(my $b=$b0;$b<$b1;$b++) {
-    for(my $g=0;$g<$size;$g++) {
-     for(my $r=0;$r<$size;$r++) {
-      push @u16,_lut_node_u16($model,$r,$g,$b,$size);
+   $SIG{TERM}='DEFAULT'; $SIG{INT}='DEFAULT';
+   # A die here would unwind into the parent's top-level eval inside the
+   # child's copy of the script (state writes, upload paths) — never escape.
+   eval {
+    my @u16;
+    my $slabs_done=0;
+    for(my $b=$b0;$b<$b1;$b++) {
+     for(my $g=0;$g<$size;$g++) {
+      for(my $r=0;$r<$size;$r++) {
+       push @u16,_lut_node_u16($model,$r,$g,$b,$size);
+      }
      }
+     $slabs_done++;
+     write_file("$tmpdir/w$w.progress",$slabs_done*$size*$size,0);
     }
-   }
-   if(open(my $fh,'>',"$tmpdir/w$w.raw")) { binmode($fh); print $fh pack('S*',@u16); close($fh); }
+    if(open(my $fh,'>',"$tmpdir/w$w.raw")) { binmode($fh); print $fh pack('S*',@u16); close($fh); }
+    1;
+   } or exit 1;
    exit 0;
   }
-  push @pids,[$w,$pid];
+  push @pids,[$w,$pid,$b1-$b0];
  }
- my $ok=1;
- foreach my $job (@pids) {
-  my $cpid=waitpid($job->[1],0);
-  $ok=0 if($cpid < 0 || ($? >> 8) != 0);
- }
+ my $ok=(scalar(@pids)==$expected_workers) ? 1 : 0;
+ kill('KILL',map { $_->[1] } @pids) if(!$ok && @pids);
+ $ok=0 if(!_lut_wait_workers(\@pids,$tmpdir,$size*$size,$size**3,$progress_cb));
  my @u16;
- if($ok) {
-  for(my $w=0;$w<$workers;$w++) {
-   my $path="$tmpdir/w$w.raw";
-   next unless(-f $path);
+ for(my $w=0;$w<$workers;$w++) {
+  my $path="$tmpdir/w$w.raw";
+  if($ok && -f $path) {
    if(open(my $fh,'<',$path)) {
     binmode($fh); local $/; my $blob=<$fh>; close($fh);
     push @u16, unpack('S*',$blob) if(defined $blob && length($blob));
    }
-   unlink($path);
   }
+  unlink($path);
+  unlink("$tmpdir/w$w.progress");
+  unlink("$tmpdir/w$w.progress.tmp");
  }
  rmdir($tmpdir);
  if(!$ok || scalar(@u16) != 3*$size*$size*$size) {
+  die "cancelled\n" if(cancelled());
   log_line("lut generate: parallel payload failed (ok=$ok n=".scalar(@u16)."), serial fallback");
-  return _generate_lut_lg_payload_serial($model,$size);
+  $progress_cb->(0,$size**3) if(ref($progress_cb) eq "CODE");
+  return _generate_lut_lg_payload_serial($model,$size,$progress_cb);
  }
  log_line("lut generate: payload ${size}^3 via $workers workers");
  return \@u16;
@@ -2353,7 +2440,12 @@ sub run_solve_only {
  $state->{"current_name"}="Generating ${cube_size}³ cube";
  $state->{"solve_progress_pct"}=45;
  write_state($state);
- my ($cube_u16,$preview_nodes)=generate_lut_cube($model,$cube_size);
+ set_lut_calculation_progress($state,"Export cube calculation",0,$cube_size**3,1);
+ my ($cube_u16,$preview_nodes)=generate_lut_cube($model,$cube_size,sub {
+  my ($current,$total)=@_;
+  set_lut_calculation_progress($state,"Export cube calculation",$current,$total,1);
+ });
+ set_lut_calculation_progress($state,"Export cube calculation",$cube_size**3,$cube_size**3,0);
  $model->{"method"}=$series_method;
  $state->{"message"}="Writing ${cube_size}³ .cube export";
  $state->{"current_name"}="Writing .cube";
@@ -4356,7 +4448,11 @@ if($config->{"solve_only"}) {
  eval { run_solve_only($config); };
  if($@) {
   my $err=$@; $err =~ s/\s+$//;
-  write_state({ status=>"error", solve_only=>json_true(), message=>"LUT solve failed: $err" });
+  if($err =~ /^cancelled$/i) {
+   write_state({ status=>"cancelled", solve_only=>json_true(), message=>"LUT solve cancelled" });
+  } else {
+   write_state({ status=>"error", solve_only=>json_true(), message=>"LUT solve failed: $err" });
+  }
   exit 1;
  }
  exit 0;
@@ -4619,12 +4715,22 @@ eval {
  $state->{"current_name"}="Generating ${cube_size}³ cube";
  $state->{"solve_progress_pct"}=40;
  write_state($state);
- ($cube_u16,$preview_nodes)=generate_lut_cube($model,$cube_size);
+ set_lut_calculation_progress($state,"Export cube calculation",0,$cube_size**3,1);
+ ($cube_u16,$preview_nodes)=generate_lut_cube($model,$cube_size,sub {
+  my ($current,$total)=@_;
+  set_lut_calculation_progress($state,"Export cube calculation",$current,$total,1);
+ });
+ set_lut_calculation_progress($state,"Export cube calculation",$cube_size**3,$cube_size**3,0);
  $state->{"message"}="Generating 33-point LG upload payload";
  $state->{"current_name"}="Generating 33³ payload";
  $state->{"solve_progress_pct"}=70;
  write_state($state);
- $payload_u16=generate_lut_lg_payload($model,33);
+ set_lut_calculation_progress($state,"LG 33³ payload calculation",0,33**3,1);
+ $payload_u16=generate_lut_lg_payload($model,33,sub {
+  my ($current,$total)=@_;
+  set_lut_calculation_progress($state,"LG 33³ payload calculation",$current,$total,1);
+ });
+ set_lut_calculation_progress($state,"LG 33³ payload calculation",33**3,33**3,0);
  }
  my $export=export_lut($cube_u16,$payload_u16,$model,$config,$cube_size);
  $state->{"export"}=$export;
@@ -5044,6 +5150,11 @@ eval {
  $state->{"phase"}=$state->{"status"};
  $state->{"current_name"}=$state->{"status"} eq "cancelled" ? "LG 3D LUT Auto Cal cancelled" : "LG 3D LUT Auto Cal error";
  $state->{"message"}=$state->{"status"} eq "cancelled" ? "3D LUT Auto Cal stopped" : $err;
+ if($state->{"lut_calculation_active"}) {
+  $state->{"lut_calculation_active"}=json_false();
+  $state->{"lut_calculation_current_nodes"}=0;
+  $state->{"lut_calculation_total_nodes"}=0;
+ }
  write_state($state);
  log_line($err);
 };

--- a/usr/bin/meter_lg_autocal.pl
+++ b/usr/bin/meter_lg_autocal.pl
@@ -8,6 +8,9 @@ use IO::Select ();
 use IO::Socket::INET ();
 use MIME::Base64 ();
 use Time::HiRes qw(sleep time);
+use FindBin qw($Bin);
+use lib "$Bin/../share/PGenerator";
+use PGAutoCalSafety qw(critical_shadow_needs_revisit autocal_solver_target_delta_e autocal_white_residual_stop_allowed autocal_restored_acceptance_needs_retry);
 
 our $PGAC_LOADED = 0;
 eval { require '/usr/share/PGenerator/PGAutoCalRun.pm'; $PGAC_LOADED = 1; 1 };
@@ -14677,9 +14680,10 @@ sub lg_autocal_26_run_hdr20_dpg_greyscale {
 	my $low_ire_reescalate_factor=defined($config->{"lg_autocal_hdr20_dpg_low_ire_reescalate_factor"}) ? ($config->{"lg_autocal_hdr20_dpg_low_ire_reescalate_factor"}+0) : 4.0;
 	$low_ire_reescalate_factor=1.0 if($low_ire_reescalate_factor < 1.0);
 	$low_ire_reescalate_factor=20.0 if($low_ire_reescalate_factor > 20.0);
-	# "Close enough that further moves only scatter the reading" band, as a
-	# multiple of the anchor's effective target dE.
-	my $low_ire_close_factor=defined($config->{"lg_autocal_hdr20_dpg_low_ire_close_factor"}) ? ($config->{"lg_autocal_hdr20_dpg_low_ire_close_factor"}+0) : 1.5;
+	# Optional "close enough that further moves only scatter the reading" band.
+	# It defaults to the exact target, so it cannot stop an above-target solve;
+	# expert callers may deliberately widen it for a known noise floor.
+	my $low_ire_close_factor=defined($config->{"lg_autocal_hdr20_dpg_low_ire_close_factor"}) ? ($config->{"lg_autocal_hdr20_dpg_low_ire_close_factor"}+0) : 1.0;
 	$low_ire_close_factor=1.0 if($low_ire_close_factor < 1.0);
 	$low_ire_close_factor=5.0 if($low_ire_close_factor > 5.0);
 	# 100% white is calibrated first and gets its own (usually larger)
@@ -14688,24 +14692,19 @@ sub lg_autocal_26_run_hdr20_dpg_greyscale {
 	my $max_inner_white=defined($config->{"lg_autocal_hdr20_dpg_white_iters"}) ? int($config->{"lg_autocal_hdr20_dpg_white_iters"}) : 16;
 	$max_inner_white=1 if($max_inner_white < 1);
 	$max_inner_white=16 if($max_inner_white > 16);
-	my $target_de=defined($config->{"lg_autocal_hdr20_dpg_target_de"}) ? ($config->{"lg_autocal_hdr20_dpg_target_de"}+0) : 0.5;
-	$target_de=0.05 if($target_de < 0.05);
-	$target_de=5.0 if($target_de > 5.0);
-	# Per-anchor target_de multiplier at low IRE. The panel's PQ EOTF floor
-	# + meter noise at very low stimulus (1.4-2% IRE) make the set target
-	# physically unreachable: e.g. target=0.5 means dE<=0.5, but the best
-	# achievable on the OLED65C2PUA / OLED48C1AUB at 1.4% is ~0.7-0.9 dE.
-	# Without relaxation the best-so-far revert logic catches every
-	# oscillation cycle, but the running best dE never crosses the unrelaxed
-	# threshold, so the worker keeps "trying" after every revert -- the
-	# 2026-06-23 1.4% slot ran 16 iters / 8.6 min for ~4 useless post-best
-	# iterations per cycle. Default 2.0 at very-low IRE matches the operator
-	# directive "double the set target": with set target 0.5 the effective
-	# target at 1.4% is 1.0; a best-so-far dE of 0.72 then converges.
-	my $target_de_low_multiplier=defined($config->{"lg_autocal_hdr20_dpg_target_de_low_multiplier"}) ? ($config->{"lg_autocal_hdr20_dpg_target_de_low_multiplier"}+0) : 1.5;
+	my $target_de=autocal_solver_target_delta_e($config,"lg_autocal_hdr20_dpg_target_de",0.5);
+	my $target_de_source=(defined($config->{"lg_autocal_hdr20_dpg_target_de"}) ? "lg_autocal_hdr20_dpg_target_de" : (defined($config->{"target_delta_e"}) ? "target_delta_e" : "fallback"));
+	$state->{"hdr20_1d_dpg_target_de"}=$target_de+0;
+	$state->{"hdr20_1d_dpg_target_de_source"}=$target_de_source;
+	log_line("HDR20 1D DPG greyscale: active target dE=".sprintf("%.3f",$target_de)." source=".$target_de_source);
+	write_state($state);
+	# Honour the operator's target at every anchor by default.  Expert callers
+	# can still opt into a relaxed low-IRE threshold explicitly for a known
+	# meter or panel noise floor.
+	my $target_de_low_multiplier=defined($config->{"lg_autocal_hdr20_dpg_target_de_low_multiplier"}) ? ($config->{"lg_autocal_hdr20_dpg_target_de_low_multiplier"}+0) : 1.0;
 	$target_de_low_multiplier=1.0 if($target_de_low_multiplier < 1.0);
 	$target_de_low_multiplier=5.0 if($target_de_low_multiplier > 5.0);
-	my $target_de_very_low_multiplier=defined($config->{"lg_autocal_hdr20_dpg_target_de_very_low_multiplier"}) ? ($config->{"lg_autocal_hdr20_dpg_target_de_very_low_multiplier"}+0) : 2.0;
+	my $target_de_very_low_multiplier=defined($config->{"lg_autocal_hdr20_dpg_target_de_very_low_multiplier"}) ? ($config->{"lg_autocal_hdr20_dpg_target_de_very_low_multiplier"}+0) : 1.0;
 	$target_de_very_low_multiplier=1.0 if($target_de_very_low_multiplier < 1.0);
 	$target_de_very_low_multiplier=5.0 if($target_de_very_low_multiplier > 5.0);
 	$target_de_very_low_multiplier=$target_de_low_multiplier if($target_de_very_low_multiplier < $target_de_low_multiplier);
@@ -14989,6 +14988,7 @@ sub lg_autocal_26_run_hdr20_dpg_greyscale {
 	if($test_mode) {
 		$white_ref=$test_white_ref+0;
 		$state->{"hdr20_1d_dpg_white_converged"}=JSON::PP::true;
+		$state->{"hdr20_1d_dpg_white_usable"}=JSON::PP::true;
 		log_line("HDR20 1D DPG greyscale: TEST MODE using snapshot white_ref=".sprintf("%.4f",$white_ref)." (provisional 100% read + white calibration skipped)");
 	} elsif(ref($white_step) eq "HASH" && !cancelled()) {
 		my $rs=fixed_lg_autocal_step($config,$white_step);
@@ -15078,14 +15078,9 @@ sub lg_autocal_26_run_hdr20_dpg_greyscale {
 		my $gamma_effective=lg_autocal_expected_gamma_for_signal_mode_and_ire($_anchor_signal_mode,$_anchor_ire);
 		$gamma_effective=1.5 if($gamma_effective+0 < 1.5);
 		$gamma_effective=3.0 if($gamma_effective+0 > 3.0);
-		# Per-anchor effective target_de: the set $target_de is the operator's
-		# intent, but at very-low IRE the panel floor + meter noise make it
-		# unreachable. Apply the IRE-tier multiplier so a best-so-far dE like
-		# 0.72 at 1.4% IRE counts as converged when the operator set 0.5 with
-		# default 2x very-low multiplier (effective 1.0). The skip-acceptance
-		# threshold must scale with the same effective target so the
-		# "instant-skip when already below 60% of target" path stays
-		# consistent with the convergence check.
+		# The effective target equals the operator's target by default. Explicit
+		# expert multiplier overrides also scale the skip-acceptance threshold so
+		# both gates remain internally consistent.
 		my $_effective_target_de=$target_de;
 		my $_effective_skip_de=$acceptance_skip_de;
 		if($_anchor_ire <= $very_low_ire_threshold) {
@@ -15630,6 +15625,7 @@ sub lg_autocal_26_run_hdr20_dpg_greyscale {
 				# fall through: the build below makes the one-more move
 			} elsif($acceptance_pending) {
 				# This read is the result of the one-more move. Decide + move on.
+				my $_acceptance_move_on=1;
 				if(defined($de) && $de+0 < $accepted_best_de+0) {
 					log_line("HDR20 1D DPG greyscale: ".$label." one-more move improved to dE=".sprintf("%.4f",$de+0).", moving on");
 				} else {
@@ -15664,8 +15660,20 @@ sub lg_autocal_26_run_hdr20_dpg_greyscale {
 						}
 					}
 					write_state($state);
+					if(autocal_restored_acceptance_needs_retry($_restored_ok,$de,$_effective_target_de)) {
+						# The restored coefficients once measured below target, but the
+						# verification read is the honest current panel state.  Do not
+						# call that historical sample converged; keep using the remaining
+						# bounded iteration budget from the verified reading.
+						$acceptance_pending=0;
+						$converged=0;
+						$conv_now=0;
+						$prev_de=$de+0;
+						$_acceptance_move_on=0;
+						log_line("HDR20 1D DPG greyscale: ".$label." restoration verify dE=".sprintf("%.4f",$de+0)." still above target ".sprintf("%.4f",$_effective_target_de+0)."; continuing solve");
+					}
 				}
-				last;
+				last if($_acceptance_move_on);
 			}
 			last if($conv_now && !$acceptance_pending);
 			# Reach the target (luminance AND white balance) with per-channel
@@ -15738,14 +15746,13 @@ sub lg_autocal_26_run_hdr20_dpg_greyscale {
 			  log_line(sprintf("HDR20 1D DPG greyscale: %s white move R=%.4f G=%.4f B=%.4f (k R=%s G=%s B=%s, lock=%s, residual=%.4f%%)",
 			   $label,($rg//1.0)+0,($gg//1.0)+0,($bg//1.0)+0,$_kn[0],$_kn[1],$_kn[2],($white_lowest_lock->{"name"}//"?"),$white_resid*100));
 			 }
-			 # Genuinely matched in light while dE is still above target: that is
-			 # the physical limit of holding the lock, not a stall. Stop at best
-			 # rather than burning the remaining budget re-reading an unchanged
-			 # panel (the pre-fix code had no such exit and spent 15 iterations
-			 # doing exactly that).
+			 # A small residual can indicate the physical/noise limit of holding
+			 # the white lock, but it must not override an operator's lower dE
+			 # target on the first correction. Require several genuine attempts
+			 # (or repeated reverts) before accepting that bounded give-up path.
 			 my $_white_stop=0;
 			 my $_white_stop_why="";
-			 if($white_resid <= 0.004 && defined($de) && ($de+0) > ($_effective_target_de+0)) {
+			 if(autocal_white_residual_stop_allowed($i,$consecutive_reverts,$white_resid,$de,$_effective_target_de)) {
 			  $_white_stop=1;
 			  $_white_stop_why=sprintf("matched to lock in light (residual=%.4f%%)",$white_resid*100);
 			 } elsif($white_span < 0.002 && $white_resid > 0.004 && defined($de) && ($de+0) > ($_effective_target_de+0)) {
@@ -15996,19 +16003,16 @@ sub lg_autocal_26_run_hdr20_dpg_greyscale {
 			}
 			push @done,{idx=>$idx,r_gain=>1.0,g_gain=>1.0,b_gain=>1.0};
 			$state->{"hdr20_1d_dpg_anchors_done"}=scalar(@done);
-			# White is good enough to proceed if it hit the strict target
-			# ($conv) OR produced a usable reading -- a real calibration whose
-			# dE simply landed just above target (e.g. 0.69 at target 0.5 is an
-			# excellent white). The earlier fail-fast aborted the whole series
-			# whenever white missed the strict target, skipping the entire
-			# greyscale. Only a total read failure (no usable reading -> the
-			# identity 1.0/1.0/1.0 DPG) aborts and suppresses the upload.
+			# A usable above-target white may still seed the remaining greyscale;
+			# only a total read failure aborts the series. Keep usability separate
+			# from convergence so continuing does not falsely claim target success.
 			my $white_usable=0;
 			if(ref($last) eq "HASH") {
 				my $wy=luminance($last);
 				$white_usable=1 if(defined($wy) && $wy+0 > 0);
 			}
-			$state->{"hdr20_1d_dpg_white_converged"}=($conv || $white_usable) ? JSON::PP::true : JSON::PP::false;
+			$state->{"hdr20_1d_dpg_white_usable"}=$white_usable ? JSON::PP::true : JSON::PP::false;
+			$state->{"hdr20_1d_dpg_white_converged"}=$conv ? JSON::PP::true : JSON::PP::false;
 			write_state($state);
 			$exit_reason="max_inner" if(!$upload_failed && !cancelled() && !$conv && $exit_reason eq "converged");
 			if(!$white_usable) {
@@ -16077,6 +16081,9 @@ sub lg_autocal_26_run_hdr20_dpg_greyscale {
 		$exit_reason="max_inner" if(!$upload_failed && !cancelled() && !$conv && $exit_reason eq "converged");
 	}
 	$exit_reason="cancelled" if(cancelled());
+	if($exit_reason eq "max_inner" && (!defined($state->{"warning"}) || $state->{"warning"} eq "")) {
+		$state->{"warning"}=sprintf("One or more HDR greyscale anchors remained above the requested dE target %.3f after their iteration budgets expired",$target_de+0);
+	}
 
 	# Apply the same post-calibration low-end smoothing to standalone HDR20.
 	# Full workflows defer it until after the 3D LUT, tone-map and measured
@@ -16127,15 +16134,13 @@ sub lg_autocal_26_run_hdr20_dpg_greyscale {
 	# operator can see both -- "final_de" is the headline (committed),
 	# "final_de_trajectory" is the diagnostic (includes reverts).
 	$state->{"hdr20_1d_dpg_final_de_trajectory"}=$max_de_overall+0;
-	# Only mark the curve as uploaded to the TV if the white reference actually
-	# converged and the upload didn't fail. A non-converged 100% block leaves
-	# the panel with the identity baseline (or whatever was previously
-	# committed) -- uploading the 1.0/1.0/1.0 no-op DPG would silently wipe the
-	# 1D LUT and break the picture, so the API must report `uploaded: false`.
+	# A usable white permits a best-effort curve to remain uploaded even if it
+	# missed the requested target; the separate convergence flag and terminal
+	# warning report that honestly. Only a read/upload failure suppresses it.
 	$state->{"hdr20_1d_dpg_uploaded"}=JSON::PP::true;
-	if($upload_failed || !$state->{"hdr20_1d_dpg_white_converged"}) {
+	if($upload_failed || !$state->{"hdr20_1d_dpg_white_usable"}) {
 		$state->{"hdr20_1d_dpg_uploaded"}=JSON::PP::false;
-		log_line("HDR20 1D DPG greyscale: skipping wire upload because white did not converge or upload_failed=1 (upload_failed=".($upload_failed?1:0).", white_converged=".($state->{"hdr20_1d_dpg_white_converged"} ? "true" : "false").")");
+		log_line("HDR20 1D DPG greyscale: marking upload unavailable because white was unusable or upload_failed=1 (upload_failed=".($upload_failed?1:0).", white_usable=".($state->{"hdr20_1d_dpg_white_usable"} ? "true" : "false").")");
 	}
 	# Calibration mode is still held ON; the commit/finalise path ends it once
 	# (end_calibration_mode) before the post-cal series read.
@@ -16404,11 +16409,10 @@ sub lg_autocal_26_run_sdr_1d_dpg_greyscale_inner {
  my $low_ire_reescalate_factor=defined($config->{"lg_autocal_sdr26_dpg_low_ire_reescalate_factor"}) ? ($config->{"lg_autocal_sdr26_dpg_low_ire_reescalate_factor"}+0) : 4.0;
  $low_ire_reescalate_factor=1.0 if($low_ire_reescalate_factor < 1.0);
  $low_ire_reescalate_factor=20.0 if($low_ire_reescalate_factor > 20.0);
- # A very-low-IRE anchor sitting within this multiple of its (relaxed) target
- # is meter-noise-limited (e.g. 0.01 cd/m2 reads scatter dE 1-5): extra
- # reverts only scatter the dE without beating the best, so keep the best and
- # stop early instead of thrashing the whole revert budget.
- my $low_ire_close_factor=defined($config->{"lg_autocal_sdr26_dpg_low_ire_close_factor"}) ? ($config->{"lg_autocal_sdr26_dpg_low_ire_close_factor"}+0) : 1.5;
+ # Optional meter-noise band around the target. It defaults to the exact
+ # target, so it cannot stop an above-target solve; expert callers may widen
+ # it deliberately for a known meter or panel noise floor.
+ my $low_ire_close_factor=defined($config->{"lg_autocal_sdr26_dpg_low_ire_close_factor"}) ? ($config->{"lg_autocal_sdr26_dpg_low_ire_close_factor"}+0) : 1.0;
  $low_ire_close_factor=1.0 if($low_ire_close_factor < 1.0);
  $low_ire_close_factor=5.0 if($low_ire_close_factor > 5.0);
  # Final-state restore re-read guard (default ON). When ENABLED, a low-IRE
@@ -16417,30 +16421,21 @@ sub lg_autocal_26_run_sdr_1d_dpg_greyscale_inner {
  # DISABLED the re-read is skipped entirely (treat as rejected without
  # bothering to read). Kept as an escape hatch so an operator who wants
  # the raw re-read path (with the noise-clobber risk) can still get it.
-   my $target_de=defined($config->{"lg_autocal_sdr26_dpg_target_de"}) ? ($config->{"lg_autocal_sdr26_dpg_target_de"}+0) : 0.5;
-  $target_de=0.05 if($target_de < 0.05);
-  $target_de=5.0 if($target_de > 5.0);
-  # Per-anchor target_de multiplier at low IRE (HDR pattern). The panel's
-  # 2.2 EOTF + meter noise at very low stimulus (2.3-4% IRE) make the set
-  # target physically unreachable -- a best-so-far dE of 0.6-0.9 is the
-  # best achievable. Without relaxation the worker keeps "trying" after
-  # every revert, wasting the iteration budget fighting back down to a
-  # target the panel can't hit. 1.5x at low IRE (default 5%) and 2.0x at
-  # very-low IRE (default 2.3%) match the operator directive "double the
-  # set target" at the noise floor.
-  my $target_de_low_multiplier=defined($config->{"lg_autocal_sdr26_dpg_target_de_low_multiplier"}) ? ($config->{"lg_autocal_sdr26_dpg_target_de_low_multiplier"}+0) : 1.5;
+  my $target_de=autocal_solver_target_delta_e($config,"lg_autocal_sdr26_dpg_target_de",0.5);
+  # Honour the operator's target at every anchor by default.  Expert callers
+  # can still opt into a relaxed low-IRE threshold explicitly for a known
+  # meter or panel noise floor.
+  my $target_de_low_multiplier=defined($config->{"lg_autocal_sdr26_dpg_target_de_low_multiplier"}) ? ($config->{"lg_autocal_sdr26_dpg_target_de_low_multiplier"}+0) : 1.0;
   $target_de_low_multiplier=1.0 if($target_de_low_multiplier < 1.0);
   $target_de_low_multiplier=5.0 if($target_de_low_multiplier > 5.0);
-  my $target_de_very_low_multiplier=defined($config->{"lg_autocal_sdr26_dpg_target_de_very_low_multiplier"}) ? ($config->{"lg_autocal_sdr26_dpg_target_de_very_low_multiplier"}+0) : 2.0;
+  my $target_de_very_low_multiplier=defined($config->{"lg_autocal_sdr26_dpg_target_de_very_low_multiplier"}) ? ($config->{"lg_autocal_sdr26_dpg_target_de_very_low_multiplier"}+0) : 1.0;
   $target_de_very_low_multiplier=1.0 if($target_de_very_low_multiplier < 1.0);
   $target_de_very_low_multiplier=5.0 if($target_de_very_low_multiplier > 5.0);
   $target_de_very_low_multiplier=$target_de_low_multiplier if($target_de_very_low_multiplier < $target_de_low_multiplier);
   my $_effective_target_de=$target_de;
-  # Very-low IRE band: 2.5 (was 2.0). The comment above documents the 2.0x
-  # relaxation as applying to "very-low IRE (default 2.3%)", but a strict
-  # < 2.0 excluded the 2.3% anchor (it fell into the 1.5x low band). 2.5
-  # captures 2.3% as intended so the deepest-shadow anchor gets the full
-  # very-low treatment (relaxed target + strongest read averaging below).
+  # Very-low IRE includes the 2.3% anchor. Multipliers are exact (1.0) by
+  # default, but the band still selects an explicit expert override and the
+  # stronger read averaging used below.
   if($_anchor_ire+0 < 2.5) {
    $_effective_target_de=$target_de*$target_de_very_low_multiplier;
   } elsif($_anchor_ire+0 < $low_ire_threshold) {
@@ -16898,6 +16893,7 @@ sub lg_autocal_26_run_sdr_1d_dpg_greyscale_inner {
    log_line("SDR26 1D DPG greyscale: ".$label." converged early (dE=".sprintf("%.4f",$de+0)." <= ".sprintf("%.2f",$_effective_target_de+0)." at i".$i."), trying one more refinement move");
    # fall through: the build below makes the one-more move
   } elsif($acceptance_pending) {
+   my $_acceptance_move_on=1;
    if(defined($de) && $de+0 < $accepted_best_de+0) {
     log_line("SDR26 1D DPG greyscale: ".$label." one-more move improved to dE=".sprintf("%.4f",$de+0).", moving on");
    } else {
@@ -16927,8 +16923,16 @@ sub lg_autocal_26_run_sdr_1d_dpg_greyscale_inner {
      }
     }
     write_state($state);
+    if(autocal_restored_acceptance_needs_retry($_restored_ok,$de,$_effective_target_de)) {
+     $acceptance_pending=0;
+     $converged=0;
+     $conv_now=0;
+     $prev_de=$de+0;
+     $_acceptance_move_on=0;
+     log_line("SDR26 1D DPG greyscale: ".$label." restoration verify dE=".sprintf("%.4f",$de+0)." still above target ".sprintf("%.4f",$_effective_target_de+0)."; continuing solve");
+    }
    }
-   last;
+   last if($_acceptance_move_on);
   }
   last if($conv_now && !$acceptance_pending);
   # Compute the per-channel gain. Three paths:
@@ -17352,11 +17356,13 @@ sub lg_autocal_26_run_sdr_1d_dpg_greyscale {
  # see the same $config->{ddc_layout} the routing implied.
  $config->{"ddc_layout"}=$_layout;
 
- # Top-level target_dE (operator's set target). Mirrors the HDR top-level
- # config knob lg_autocal_hdr20_dpg_target_de. Default 0.5.
- my $target_de=defined($config->{"lg_autocal_sdr26_dpg_target_de"}) ? ($config->{"lg_autocal_sdr26_dpg_target_de"}+0) : 0.5;
- $target_de=0.05 if($target_de+0 < 0.05);
- $target_de=5.0 if($target_de+0 > 5.0);
+ # Top-level target_dE (operator's set target). The specialised key remains an
+ # explicit override, matching the HDR DPG worker.
+ my $target_de=autocal_solver_target_delta_e($config,"lg_autocal_sdr26_dpg_target_de",0.5);
+ $state->{"sdr26_1d_dpg_target_de"}=$target_de+0;
+ $state->{"sdr26_1d_dpg_target_de_source"}=defined($config->{"lg_autocal_sdr26_dpg_target_de"}) ? "lg_autocal_sdr26_dpg_target_de" : (defined($config->{"target_delta_e"}) ? "target_delta_e" : "fallback");
+ log_line("SDR26 1D DPG greyscale: active target dE=".sprintf("%.3f",$target_de)." source=".$state->{"sdr26_1d_dpg_target_de_source"});
+ write_state($state);
 
  # SDR26 anchor tables. Three mutually exclusive models keyed on
  # (transport_range, color_format):
@@ -17853,6 +17859,7 @@ sub lg_autocal_26_run_sdr_1d_dpg_greyscale {
  my $max_de_overall=0;
  my $exit_reason="converged";
  my $upload_failed=0;
+ my @critical_shadow_revisits;
 
  my $step_num=0;
  # --- 100% white first: calibrate its white balance, then anchor the peak
@@ -17903,7 +17910,8 @@ sub lg_autocal_26_run_sdr_1d_dpg_greyscale {
     my $wy=luminance($last);
     $white_usable=1 if(defined($wy) && $wy+0 > 0);
    }
-   $state->{"sdr_1d_dpg_white_converged"}=($conv || $white_usable) ? JSON::PP::true : JSON::PP::false;
+   $state->{"sdr_1d_dpg_white_usable"}=$white_usable ? JSON::PP::true : JSON::PP::false;
+   $state->{"sdr_1d_dpg_white_converged"}=$conv ? JSON::PP::true : JSON::PP::false;
    # Flag the calibrated 109 step so the @rest loop skips it (per-anchor
    # loop skip rule: `autocal_step_is_white($step) && $step->{sdr26_white_peak_done}`).
    # 99 and 105 do NOT get this flag and are processed individually below
@@ -17965,7 +17973,26 @@ if(ref($state) eq "HASH" && !defined($state->{"sdr_1d_dpg_body_target_logged"}) 
    $config,$state,$rs,$idx,$label,$budget,$white_ref,$target_x,$target_y,$picture_mode,\@{$current_dpg},\@done,$cal_active
   );
   $total_inner_iters+=$inner_iters;
-  $max_de_overall=$max_de_anchor if($max_de_anchor+0 > $max_de_overall+0);
+  my $_critical_shadow_best_de=(ref($state) eq "HASH" && defined($state->{current_delta_e}))
+   ? ($state->{current_delta_e}+0) : ($max_de_anchor+0);
+  my $_critical_shadow_revisit=critical_shadow_needs_revisit($rs,$conv);
+  if($_critical_shadow_revisit) {
+   push @critical_shadow_revisits,{
+    step=>clone_picture($step),
+    initial_de=>$_critical_shadow_best_de+0,
+   };
+   if(ref($state) eq "HASH") {
+    $state->{sdr_1d_dpg_shadow_revisit}={
+     status=>"queued",
+     ire=>$_step_ire+0,
+     initial_de=>$_critical_shadow_best_de+0,
+    };
+    write_state($state);
+   }
+   log_line(sprintf("SDR26 1D DPG greyscale: queued %.1f%% critical-shadow revisit after neighbouring dark-detail anchors (initial best dE=%.4f)",$_step_ire,$_critical_shadow_best_de+0));
+  } else {
+   $max_de_overall=$max_de_anchor if($max_de_anchor+0 > $max_de_overall+0);
+  }
   $cal_active=1 if($cal_active_inner);
   $upload_failed=1 if($inner_upload_failed);
   # Full 100% recal: refresh white_ref so 95%..2.3% targets track the
@@ -17993,9 +18020,81 @@ if(ref($state) eq "HASH" && !defined($state->{"sdr_1d_dpg_body_target_logged"}) 
    $state->{"sdr_1d_dpg_last_anchor_converged"}=$conv ? JSON::PP::true : JSON::PP::false;
    write_state($state);
   }
-  $exit_reason="max_inner" if(!$upload_failed && !cancelled() && !$conv && $exit_reason eq "converged");
+  $exit_reason="max_inner" if(!$upload_failed && !cancelled() && !$conv && !$_critical_shadow_revisit && $exit_reason eq "converged");
+ }
+
+ # A failed 2.3% point can share its low-end curve neighbourhood with the
+ # Dark Detail 2%/2.7% points which run later.  Re-open it once those
+ # neighbours have settled, with a fresh damping/revert history, instead of
+ # silently committing the first exhausted attempt.
+ foreach my $pending (@critical_shadow_revisits) {
+  last if(cancelled() || $upload_failed);
+  my $step=$pending->{step};
+  my $rs=fixed_lg_autocal_step($config,$step);
+  my $idx=$idx_for_sdr->($rs);
+  next if(!defined($idx));
+  my $_step_ire=defined($rs->{ire}) ? ($rs->{ire}+0) : 2.3;
+  my $label=($rs->{name}||(format_percent($_step_ire)."%"));
+  $label.=" (revisit)" if($label !~ /\(revisit\)$/);
+  my $budget=defined($config->{lg_autocal_sdr26_dpg_shadow_revisit_budget})
+   ? int($config->{lg_autocal_sdr26_dpg_shadow_revisit_budget}) : 8;
+  $budget=4 if($budget < 4);
+  $budget=12 if($budget > 12);
+  $total_steps++;
+  $step_num++;
+  if(ref($state) eq "HASH") {
+   $state->{current_name}="SDR26 1D DPG $label";
+   $state->{current_ire}=$_step_ire+0;
+   $state->{current_step}=$step_num+0;
+   $state->{total_steps}=$total_steps+0;
+   $state->{sdr_1d_dpg_shadow_revisit}={
+    status=>"running",
+    ire=>$_step_ire+0,
+    initial_de=>$pending->{initial_de}+0,
+    budget=>$budget+0,
+   };
+   write_state($state);
+  }
+  log_line(sprintf("SDR26 1D DPG greyscale: starting %.1f%% critical-shadow revisit after neighbours (initial best dE=%.4f, budget=%d)",$_step_ire,$pending->{initial_de}+0,$budget));
+  my ($conv,$last,$final_dpg,$inner_iters,$max_de_anchor,$cal_active_inner,$inner_upload_failed)=lg_autocal_26_run_sdr_1d_dpg_greyscale_inner(
+   $config,$state,$rs,$idx,$label,$budget,$white_ref,$target_x,$target_y,$picture_mode,\@{$current_dpg},\@done,$cal_active
+  );
+  $total_inner_iters+=$inner_iters;
+  my $revisit_best_de=(ref($state) eq "HASH" && defined($state->{current_delta_e}))
+   ? ($state->{current_delta_e}+0)
+   : (($max_de_anchor+0) > 0 ? ($max_de_anchor+0) : ($pending->{initial_de}+0));
+  $max_de_overall=$max_de_anchor if($max_de_anchor+0 > $max_de_overall+0);
+  $cal_active=1 if($cal_active_inner);
+  $upload_failed=1 if($inner_upload_failed);
+  push @done,{idx=>$idx,r_gain=>1.0,g_gain=>1.0,b_gain=>1.0};
+  if(ref($state) eq "HASH") {
+   $state->{sdr_1d_dpg_anchors_done}=scalar(@done);
+   $state->{sdr_1d_dpg_last_anchor_converged}=$conv ? JSON::PP::true : JSON::PP::false;
+   $state->{sdr_1d_dpg_shadow_revisit}={
+    status=>$conv ? "converged" : "unresolved",
+    ire=>$_step_ire+0,
+    initial_de=>$pending->{initial_de}+0,
+    final_de=>$revisit_best_de+0,
+    iterations=>$inner_iters+0,
+   };
+   if(!$conv) {
+    $state->{sdr_1d_dpg_unresolved_critical_anchors}=[] if(ref($state->{sdr_1d_dpg_unresolved_critical_anchors}) ne "ARRAY");
+    push @{$state->{sdr_1d_dpg_unresolved_critical_anchors}},{ire=>$_step_ire+0,de=>$revisit_best_de+0};
+    $state->{warning}=sprintf("Critical %.1f%% shadow anchor remained unconverged after automatic revisit (best dE %.3f)",$_step_ire,$revisit_best_de+0);
+   }
+   write_state($state);
+  }
+  if($conv) {
+   log_line(sprintf("SDR26 1D DPG greyscale: %.1f%% critical-shadow revisit converged at dE %.4f",$_step_ire,$revisit_best_de+0));
+  } else {
+   $exit_reason="max_inner" if($exit_reason eq "converged");
+   log_line(sprintf("SDR26 1D DPG greyscale: WARNING %.1f%% critical-shadow revisit unresolved at best dE %.4f",$_step_ire,$revisit_best_de+0));
+  }
  }
  $exit_reason="cancelled" if(cancelled());
+ if($exit_reason eq "max_inner" && (!defined($state->{warning}) || $state->{warning} eq "")) {
+  $state->{warning}=sprintf("One or more SDR greyscale anchors remained above the requested dE target %.3f after their iteration budgets expired",$target_de+0);
+ }
 
  # Post-calibration shadow smoothing, applied ONCE here rather than per
  # iteration: smoothing inside the loop would move the anchor the solver just
@@ -18053,15 +18152,13 @@ if(ref($state) eq "HASH" && !defined($state->{"sdr_1d_dpg_body_target_logged"}) 
  # the WebUI chart can render the matching 2.2 target line via
  # meterGreyChartTargetGammaSelection rather than the BT.1886 dropdown default.
  $state->{"sdr_1d_dpg_target_gamma"}="2.2";
- # Only mark the curve as uploaded to the TV if the white reference actually
- # converged and the upload didn't fail. A non-converged 100% block leaves
- # the panel with the identity baseline -- uploading the 1.0/1.0/1.0 no-op
- # DPG would silently wipe the 1D LUT and break the picture, so the API must
- # report uploaded: false.
+ # A usable white permits a best-effort curve to remain uploaded even if it
+ # missed the requested target; the separate convergence flag and terminal
+ # warning report that honestly. Only a read/upload failure suppresses it.
  $state->{"sdr_1d_dpg_uploaded"}=JSON::PP::true;
- if($upload_failed || !$state->{"sdr_1d_dpg_white_converged"}) {
+ if($upload_failed || !$state->{"sdr_1d_dpg_white_usable"}) {
   $state->{"sdr_1d_dpg_uploaded"}=JSON::PP::false;
-  log_line("SDR26 1D DPG greyscale: skipping wire upload because white did not converge or upload_failed=1 (upload_failed=".($upload_failed?1:0).", white_converged=".($state->{"sdr_1d_dpg_white_converged"} ? "true" : "false").")");
+  log_line("SDR26 1D DPG greyscale: marking upload unavailable because white was unusable or upload_failed=1 (upload_failed=".($upload_failed?1:0).", white_usable=".($state->{"sdr_1d_dpg_white_usable"} ? "true" : "false").")");
  }
  # Calibration mode is still held ON; the commit/finalise path ends it once
  # (single-socket commit) before the post-cal series read.
@@ -21951,8 +22048,9 @@ $LG_AUTOCAL_DDC_LAYOUT=ddc_layout_for_signal_mode($signal_mode);
 $LG_AUTOCAL_DARK_DETAIL=$config->{"dark_detail"} ? 1 : 0;
 if($LG_AUTOCAL_DARK_DETAIL) {
  my @dd=ddc_dark_detail_fillers_for_layout($LG_AUTOCAL_DDC_LAYOUT);
+ my @dd_slots=ddc_slots_for_layout($LG_AUTOCAL_DDC_LAYOUT);
  log_line("Dark Detail enabled: layout=$LG_AUTOCAL_DDC_LAYOUT adds ".scalar(@dd)." patches (".join(", ",@dd).") -> "
-  .scalar(ddc_slots_for_layout($LG_AUTOCAL_DDC_LAYOUT))." slots total; spline anchors unchanged");
+  .scalar(@dd_slots)." slots total; spline anchors unchanged");
 }
 my $max_iterations=defined($config->{"max_iterations"}) ? int($config->{"max_iterations"}) : 80;
 my $min_iterations=autocal_config_is_touchup($config) ? 4 : 12;
@@ -26808,8 +26906,13 @@ eval {
 	  $state->{"message"}="Auto Cal stopped";
 	 } else {
 	 $state->{"status"}="complete";
-	 $state->{"current_name"}="Auto Cal complete";
-	 $state->{"message"}="Auto Cal complete";
+	 if(defined($state->{"warning"}) && $state->{"warning"} ne "") {
+	  $state->{"current_name"}="Auto Cal complete with warning";
+	  $state->{"message"}="Auto Cal complete with warning: ".$state->{"warning"};
+	 } else {
+	  $state->{"current_name"}="Auto Cal complete";
+	  $state->{"message"}="Auto Cal complete";
+	 }
 	 $state->{"completed_at"}=int(time()*1000);
 	 $state->{"elapsed_ms"}=$state->{"completed_at"}-(($state->{"started_at"}||$state->{"completed_at"})+0);
 	 $state->{"elapsed_ms"}=0 if($state->{"elapsed_ms"}<0);

--- a/usr/bin/meter_lg_autocal.pl
+++ b/usr/bin/meter_lg_autocal.pl
@@ -274,30 +274,6 @@ sub api_json {
  return { status=>"error", message=>"Invalid Web UI API response" };
 }
 
-# Worker-side launch boundary check. The WebUI performs the same check before
-# opening the wizard, but the TV can power off later or a caller can start the
-# endpoint directly. Require a definite CEC `on` result before resets,
-# calibration mode, pattern output, or meter reads begin.
-sub verify_lg_tv_power_for_autocal {
- my ($state)=@_;
- if(ref($state) eq "HASH") {
-  $state->{"phase"}="preparing";
-  $state->{"current_name"}="Verifying LG TV power";
-  $state->{"message"}="Checking that the LG TV is powered on";
-  write_state($state);
- }
- my $status=api_json("GET","/api/lg/status",undef,10);
- my $power=(ref($status) eq "HASH") ? lc($status->{"tv_power"}||"") : "";
- $power=~s/^\s+|\s+$//g;
- return "LG TV is powered off. Turn it on and wait for it to finish starting before Auto Cal."
-  if($power eq "standby" || $power eq "off" || $power eq "powering-off");
- return "LG TV is still starting. Wait until it is fully on before Auto Cal."
-  if($power eq "powering-on");
- return "Unable to verify that the LG TV is powered on. Turn it on, wait for CEC to report On, then try Auto Cal again."
-  if($power ne "on");
- return undef;
-}
-
 sub shell_quote {
  my ($text)=@_;
  $text="" if(!defined($text));
@@ -22073,8 +22049,12 @@ my $active_picture_mode_for_cleanup="";
 
 eval {
  die "No greyscale steps were supplied" if(!@{$steps});
- my $tv_power_error=verify_lg_tv_power_for_autocal($state);
- die $tv_power_error if(defined($tv_power_error) && $tv_power_error ne "");
+ # CEC can be stale or unknown even when WebOS is reachable, so no CEC reading
+ # gates this run. Reachability is established by read_initial_picture_settings
+ # further down, which is unconditional and dies on failure. The three restore/
+ # reset calls immediately below are NOT that authority -- every UI launcher
+ # posts restore_factory_levels and reset_ddc_baseline as false, so the first
+ # two return without touching the TV, and the third only acts on hdr10.
  my $level_restore_error=restore_factory_levels_for_autocal($config,$state);
  die $level_restore_error if($level_restore_error);
  my $reset_error=reset_ddc_baseline_for_autocal($config,$state);

--- a/usr/sbin/pgenerator-lg
+++ b/usr/sbin/pgenerator-lg
@@ -230,6 +230,48 @@ sub lg_picture_mode_signal_examples (@) {
  return ();
 }
 
+# Picture-mode selection on generations with readable WebOS settings uses the
+# public SSAP endpoint with the smallest possible payload.  The former
+# current_app/input-scoped Luna write could acknowledge success while leaving
+# a G3 on its previous foreground HDMI picture-mode bank.  A separate
+# readback in lg_picture_set_workflow is the settings-write success authority.
+sub lg_picture_mode_ssap_payload (@) {
+ my $picture_mode=shift;
+ $picture_mode="" if(!defined($picture_mode));
+ return {
+  category => "picture",
+  settings => { pictureMode => $picture_mode },
+ };
+}
+
+# Do not use map_picture_mode_label_to_ddc_name for verification.  That is an
+# input-alias map and intentionally folds distinct modes (aps/eco=>standard,
+# sports=>vivid, cinemaHome=>cinema); using it on the TV's reply would recreate
+# the false-success bug.  Readback matching only normalises spelling plus
+# hardware-observed write/read enum equivalents.
+sub lg_picture_mode_readback_canonical (@) {
+ my $name=shift;
+ $name="" if(!defined($name));
+ $name=lc($name);
+ $name=~s/[\s_\-]+//g;
+ my %readback_synonym=(
+  # C1/C2: writing dolbyHdrCinema reads back dolbyHdrCinemaDark (sometimes
+  # rendered as dolby_hdr_cinema_dark).  This is the dark DV reference mode.
+  "dolbyhdrcinemadark" => "dolbyhdrcinema",
+  # Newer generations report the game enum under its Game Optimizer name.
+  "gameoptimizer" => "game",
+ );
+ return $readback_synonym{$name}||$name;
+}
+
+sub lg_picture_mode_readback_matches (@) {
+ my ($requested,$observed)=@_;
+ my $requested_mode=&lg_picture_mode_readback_canonical($requested);
+ my $observed_mode=&lg_picture_mode_readback_canonical($observed);
+ return 0 if($requested_mode eq "" || $observed_mode eq "");
+ return ($requested_mode eq $observed_mode) ? 1 : 0;
+}
+
 
 $WS_GUID="258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
 $REQUEST_ENV="PGEN_LG_REQUEST_B64";
@@ -5520,6 +5562,20 @@ sub lg_picture_set_workflow (@) {
  $settings->{"pictureMode"}=$mapped_caller_picture_mode if($mapped_caller_picture_mode ne "");
  $caller_picture_mode=$mapped_caller_picture_mode;
  my $picture_mode_only=($caller_picture_mode ne "" && scalar(keys(%{$settings}))==1) ? 1 : 0;
+ # Mandatory verification is correct only when this generation actually
+ # exposes pictureMode through getSystemSettings.  C1/B1/G1/Z1 and other
+ # DDC-only sets mark picture_mode_read_forbidden: their accepted palm/Luna
+ # bridge write is intentionally handled by the generation-specific branch
+ # below and an empty public readback means "unverifiable", not "failed".
+ my $picture_mode_readback_supported=($generation->{"picture_mode_read_forbidden"}) ? 0 : 1;
+ my $picture_mode_readback_required=($picture_mode_only && $picture_mode_readback_supported) ? 1 : 0;
+ if($picture_mode_only) {
+  if($picture_mode_readback_supported) {
+   push(@{$readback_keys},"pictureMode") if(!grep { $_ eq "pictureMode" } @{$readback_keys});
+  } else {
+   @{$readback_keys}=grep { $_ ne "pictureMode" } @{$readback_keys};
+  }
+ }
  my $active_picture_mode=$caller_picture_mode || $fallback_picture_mode;
  if($picture_mode_only && $generation->{"ddc_only_white_balance"}) {
   # This generation does not expose pictureMode over the public ssap://
@@ -5580,7 +5636,7 @@ sub lg_picture_set_workflow (@) {
     # "verified" on sets that can answer it.
     $palm_switched=1;
     $palm_attempted=$attempt->{"label"};
-    $palm_verified=1 if($palm_after ne "" && lc($palm_after) eq lc($active_picture_mode));
+    $palm_verified=1 if(&lg_picture_mode_readback_matches($active_picture_mode,$palm_after));
     last;
    }
   }
@@ -5679,22 +5735,12 @@ sub lg_picture_set_workflow (@) {
   };
  }
 
- my $set_payload={
+ my $set_payload=$picture_mode_only
+  ? &lg_picture_mode_ssap_payload($active_picture_mode)
+  : {
 	  category => "picture",
 	  settings => $settings_to_apply,
 	 };
- if($picture_mode_only) {
-  # Bind the Luna write to the foreground HDMI application. A bare
-  # pictureMode database write changes the reported preset but can leave the
-  # active Dolby Vision video pipeline detached on the C2. current_app alone
-  # is insufficient there; the input dimension identifies the live pipeline
-  # that must perform the mode transition.
-  $set_payload->{"current_app"}=&json_true();
-  $set_payload->{"dimension"}={
-   input => $tv_input,
-   "_3dStatus" => "2d",
-  } if($tv_input ne "");
- }
  my $panel_light_category=($panel_light_only && $tv_input ne "" && $active_picture_mode ne "") ? "picture\$".$tv_input.".".$active_picture_mode.".2d.x" : "";
  $set_payload->{"dimension"}={ pictureMode => $active_picture_mode } if($active_picture_mode ne "" && !$picture_mode_only && !$panel_light_only);
 
@@ -5810,13 +5856,18 @@ sub lg_picture_set_workflow (@) {
   return &json_error($ddc_message,$extra);
  }
 
- # Picture-mode transitions must use the internal Luna settings service.
- # The public SSAP route can update/read back pictureMode without making the
- # corresponding active HDMI pipeline transition on some Dolby Vision modes.
- # Other picture controls continue to use the normal SSAP route.
- my $response=$picture_mode_only
-  ? &lg_luna_request($session,"set_picture_mode_active_app","com.webos.settingsservice/setSystemSettings",$set_payload,$connect_timeout + 2)
-  : &lg_request($session,"set_picture_settings","settings/setSystemSettings",$set_payload,$connect_timeout + 2);
+ # A readable generation changes modes through the minimal public SSAP write.
+ # The independent poll below, rather than this acknowledgement, decides
+ # success.  DDC-only generations returned from their palm/Luna bridge branch
+ # above and never reach this route.
+ my $picture_mode_write_path=$picture_mode_only ? "ssap://settings/setSystemSettings" : "";
+ my $response=&lg_request(
+  $session,
+  $picture_mode_only ? "set_picture_mode" : "set_picture_settings",
+  "settings/setSystemSettings",
+  $set_payload,
+  $connect_timeout + 2
+ );
  if(ref($response) ne "HASH") {
   &websocket_close($session);
   &diag_log_append("picture_set:no-response",{ ip => $ip, picture_mode => $active_picture_mode });
@@ -5972,9 +6023,12 @@ sub lg_picture_set_workflow (@) {
 	    &diag_log_append($fallback->{"fail_label"},{ ip => $ip, picture_mode => $active_picture_mode, tv_input => $tv_input, category => $category, response => $fallback_response, message => $fallback_message });
 	   }
 	  }
-  if($failed && !$picture_mode_only && !$panel_light_only && ($failure_message =~ /401\s+insufficient permissions/i || $failure_message =~ /insufficient permissions/i)) {
+  # Client keys without public settings-write permission get one minimal Luna
+  # fallback.  Mode-only writes retain the unscoped payload and still have to
+  # pass the independent readback; an acknowledgement never becomes proof.
+  if($failed && !$panel_light_only && ($failure_message =~ /401\s+insufficient permissions/i || $failure_message =~ /insufficient permissions/i)) {
    my $luna_payload=$set_payload;
-   if($tv_input ne "" && $active_picture_mode ne "") {
+   if(!$picture_mode_only && $tv_input ne "" && $active_picture_mode ne "") {
     $luna_payload={
      category => "picture\$".$tv_input.".".$active_picture_mode.".2d.x",
      settings => $settings_to_apply,
@@ -5985,6 +6039,8 @@ sub lg_picture_set_workflow (@) {
    if(!$luna_failed && ref($luna_response) eq "HASH") {
     &diag_log_append("picture_set:luna-ok",{ ip => $ip, picture_mode => $active_picture_mode, tv_input => $tv_input, category => $luna_payload->{"category"}||"", applied => $settings_to_apply, response => $luna_response });
     $failed=0;
+    $response=$luna_response;
+    $picture_mode_write_path="luna://com.webos.settingsservice/setSystemSettings" if($picture_mode_only);
    } else {
     if($failed) {
     &websocket_close($session);
@@ -6011,6 +6067,9 @@ sub lg_picture_set_workflow (@) {
   }
  }
 	 my $settings_after={};
+	 my $picture_mode_readback_verified=0;
+	 my $picture_mode_readback_attempts=0;
+	 my $observed_picture_mode="";
 	  if(@{$readback_keys}) {
 	  if($panel_light_only) {
 	   my @readback_payloads=();
@@ -6053,6 +6112,41 @@ sub lg_picture_set_workflow (@) {
 	    last if(%{$settings_after} && $verified);
 	    select(undef,undef,undef,0.4) if($read_attempt<13);
 	   }
+	  } elsif($picture_mode_readback_required) {
+	   # WebOS can acknowledge a write that did not update the reported
+	   # foreground settings bank. Poll independently for up to five seconds and
+	   # accept only a strict enum match (plus the explicit hardware synonyms
+	   # above). The request is deliberately unscoped, matching the minimal write
+	   # and the foreground bank the TV itself reports.
+	   #
+	   # This reads the same settings plane the write updated. It detects ignored
+	   # writes, but cannot prove that the live video pipeline transitioned with
+	   # the database (a C2 Dolby Vision limitation retained from PR #30's review;
+	   # the public route was live-validated on a G3 in SDR). Nor can either side
+	   # prove that the TV is actually displaying $tv_input: both act on the bank
+	   # WebOS considers foreground.
+	   my $poll_deadline=time() + 5;
+	   my $poll_timeout=($connect_timeout < 2) ? $connect_timeout : 2;
+	   for(my $read_attempt=0;$read_attempt<10;$read_attempt++) {
+	    $picture_mode_readback_attempts=$read_attempt + 1;
+	    my $followup=&lg_request($session,"get_picture_mode_after_${read_attempt}","settings/getSystemSettings",{
+	     category => "picture",
+	     keys => ["pictureMode"],
+	    },$poll_timeout);
+	    my ($followup_failed,$followup_failure_message)=&response_is_app_failure($followup);
+	    if(!$followup_failed && ref($followup) eq "HASH"
+	       && ref($followup->{"payload"}) eq "HASH"
+	       && ref($followup->{"payload"}{"settings"}) eq "HASH") {
+	     $observed_picture_mode=$followup->{"payload"}{"settings"}{"pictureMode"}||"";
+	     $settings_after=$followup->{"payload"}{"settings"};
+	     if(&lg_picture_mode_readback_matches($active_picture_mode,$observed_picture_mode)) {
+	      $picture_mode_readback_verified=1;
+	      last;
+	     }
+	    }
+	    last if(time() >= $poll_deadline);
+	    select(undef,undef,undef,0.35) if($read_attempt<9);
+	   }
 	  } else {
 	   my $readback_category="picture";
 		   if(!$native_white_balance && !$picture_mode_only && $tv_input ne "" && $active_picture_mode ne "") {
@@ -6069,7 +6163,31 @@ sub lg_picture_set_workflow (@) {
 	   }
 	  }
 		 }
-	 if($panel_light_only && !%{$settings_after}) {
+	 if($picture_mode_readback_required && !$picture_mode_readback_verified) {
+	  &websocket_close($session);
+	  &diag_log_append("picture_set:mode-readback-mismatch",{
+	   ip => $ip,
+	   requested_picture_mode => $active_picture_mode,
+	   observed_picture_mode => $observed_picture_mode,
+	   readback_attempts => $picture_mode_readback_attempts,
+	   response => $response,
+	  });
+	  my $message=$observed_picture_mode ne ""
+	   ? "LG TV acknowledged the picture-mode request for '$active_picture_mode' but remained on '$observed_picture_mode'. Click Refresh on the Display card to resync the picture controls with the TV."
+	   : "LG TV acknowledged the picture-mode request for '$active_picture_mode' but did not return a verified picture-mode readback. Click Refresh on the Display card to resync the picture controls with the TV.";
+	  return &json_error($message,{
+	   ip => $ip,
+	   active_picture_mode => $active_picture_mode,
+	   requested_picture_mode => $active_picture_mode,
+	   observed_picture_mode => $observed_picture_mode,
+	   picture_mode_readback_supported => &json_true(),
+	   picture_mode_readback_attempts => $picture_mode_readback_attempts,
+	   picture_mode_write_path => $picture_mode_write_path,
+	   error_code => "picture-mode-readback-mismatch",
+	   repair_hint => "Click Refresh on the Display card to resync the picture controls.",
+	   raw_response => $response,
+	  });
+	 } elsif($panel_light_only && !%{$settings_after}) {
 	  &websocket_close($session);
 	  return &json_error("LG TV acknowledged the panel-light write but did not return a verified readback.",{
 	   ip => $ip,
@@ -6082,13 +6200,29 @@ sub lg_picture_set_workflow (@) {
   $settings_after->{"pictureMode"}=$active_picture_mode if($active_picture_mode ne "");
  }
  &websocket_close($session);
- &diag_log_append("picture_set:ok",{ ip => $ip, picture_mode => $active_picture_mode, applied => $settings_to_apply, settings_after => $settings_after });
+ &diag_log_append("picture_set:ok",{
+  ip => $ip,
+  picture_mode => $active_picture_mode,
+  applied => $settings_to_apply,
+  settings_after => $settings_after,
+  ($picture_mode_only ? (
+   picture_mode_readback_supported => &json_bool($picture_mode_readback_supported),
+   picture_mode_readback_verified => &json_bool($picture_mode_readback_verified),
+   picture_mode_readback_attempts => $picture_mode_readback_attempts,
+  ) : ()),
+ });
  return &json_ok({
   ip => $ip,
   client_key => $auth->{"client_key"},
   picture_settings => $settings_after,
   applied => $settings_to_apply,
   active_picture_mode => $active_picture_mode,
+	  ($picture_mode_only ? (
+	   picture_mode_readback_supported => &json_bool($picture_mode_readback_supported),
+	   picture_mode_readback_verified => &json_bool($picture_mode_readback_verified),
+	   picture_mode_readback_attempts => $picture_mode_readback_attempts,
+	   picture_mode_write_path => $picture_mode_write_path,
+	  ) : ()),
 	  calibration_mode => &json_bool($keep_calibration_mode && $ddc_white_balance_only),
   hello_info => $auth->{"hello_info"},
   system_info => $auth->{"system_info"},

--- a/usr/share/PGenerator/PGAutoCalSafety.pm
+++ b/usr/share/PGenerator/PGAutoCalSafety.pm
@@ -1,0 +1,165 @@
+package PGAutoCalSafety;
+
+use strict;
+use warnings;
+use Exporter qw(import);
+use Scalar::Util qw(looks_like_number);
+
+our @EXPORT_OK = qw(
+ profile_reading_plausibility_error
+ profile_primary_monotonicity_error
+ critical_shadow_needs_revisit
+ autocal_solver_target_delta_e
+ autocal_white_residual_stop_allowed
+ autocal_restored_acceptance_needs_retry
+);
+
+sub _reading_xyz {
+ my ($reading)=@_;
+ return undef if(ref($reading) ne "HASH");
+ return undef if(!defined($reading->{X}) || !defined($reading->{Y}) || !defined($reading->{Z}));
+ return undef if(!looks_like_number($reading->{X}) || !looks_like_number($reading->{Y}) || !looks_like_number($reading->{Z}));
+ return [ $reading->{X}+0, $reading->{Y}+0, $reading->{Z}+0 ];
+}
+
+sub _step_is_nonblack {
+ my ($step)=@_;
+ return 0 if(ref($step) ne "HASH");
+ return 0 if(lc($step->{kind}||"") eq "black");
+ foreach my $key (qw(signal_r_pct signal_g_pct signal_b_pct)) {
+  return 1 if(defined($step->{$key}) && looks_like_number($step->{$key}) && ($step->{$key}+0) > 0);
+ }
+ return 1 if(defined($step->{level}) && looks_like_number($step->{level}) && ($step->{level}+0) > 0);
+ return 1 if(defined($step->{ire}) && looks_like_number($step->{ire}) && ($step->{ire}+0) > 0);
+ return 0;
+}
+
+# Reject readings which cannot physically describe the requested patch.  The
+# threshold is deliberately far below even a 5% blue OLED patch, but above an
+# exact/stale black result.  A black patch may legitimately be XYZ 0/0/0.
+sub profile_reading_plausibility_error {
+ my ($step,$reading,$minimum_y)=@_;
+ my $xyz=_reading_xyz($reading);
+ return "returned no numeric XYZ" if(!$xyz);
+ foreach my $value (@{$xyz}) {
+  return "returned negative XYZ" if($value < -0.001);
+ }
+ return undef if(!_step_is_nonblack($step));
+ $minimum_y=0.001 if(!defined($minimum_y) || !looks_like_number($minimum_y) || $minimum_y < 0);
+ my $sum=$xyz->[0]+$xyz->[1]+$xyz->[2];
+ return sprintf("non-black patch returned black XYZ (%.6f/%.6f/%.6f)",@{$xyz})
+  if($xyz->[1] <= $minimum_y && $sum <= ($minimum_y*3));
+ return undef;
+}
+
+sub _pure_primary_axis {
+ my ($step)=@_;
+ return if(ref($step) ne "HASH");
+ my @pct=map {
+  (defined($step->{$_}) && looks_like_number($step->{$_})) ? ($step->{$_}+0) : 0
+ } qw(signal_r_pct signal_g_pct signal_b_pct);
+ my @active=grep { $pct[$_] > 0 } (0..2);
+ return if(@active != 1);
+ my $axis=$active[0];
+ return ($axis,$pct[$axis]);
+}
+
+# A higher point on the same pure-primary ramp must not collapse below the
+# preceding point.  A generous 65% floor tolerates panel drift and noise while
+# catching endpoint failures such as 90% blue -> valid, 100% blue -> black.
+sub profile_primary_monotonicity_error {
+ my ($step,$reading,$previous_entries,$minimum_ratio)=@_;
+ return undef if(ref($previous_entries) ne "ARRAY");
+ my ($axis,$level)=_pure_primary_axis($step);
+ return undef if(!defined($axis) || $level < 10);
+ my ($previous,$previous_level);
+ foreach my $entry (@{$previous_entries}) {
+  next if(ref($entry) ne "HASH");
+  my ($prior_axis,$prior_level)=_pure_primary_axis($entry->{step});
+  next if(!defined($prior_axis) || $prior_axis != $axis || $prior_level >= $level);
+  next if(defined($previous_level) && $prior_level <= $previous_level);
+  my $xyz=_reading_xyz($entry->{reading});
+  next if(!$xyz);
+  $previous=$xyz;
+  $previous_level=$prior_level;
+ }
+ return undef if(!$previous);
+ my $current=_reading_xyz($reading);
+ return "returned no numeric XYZ" if(!$current);
+ $minimum_ratio=0.65 if(!defined($minimum_ratio) || !looks_like_number($minimum_ratio) || $minimum_ratio <= 0 || $minimum_ratio >= 1);
+ my @axis_names=qw(red green blue);
+ my $dominant=$axis==0 ? 0 : ($axis==1 ? 1 : 2);
+ return sprintf(
+  "%s ramp collapsed at %.3g%% (dominant %.6f after %.3g%% %.6f)",
+  $axis_names[$axis],$level,$current->[$dominant],$previous_level,$previous->[$dominant]
+ ) if($previous->[$dominant] > 0 && $current->[$dominant] < ($previous->[$dominant]*$minimum_ratio));
+ return sprintf(
+  "%s luminance ramp collapsed at %.3g%% (Y %.6f after %.3g%% %.6f)",
+  $axis_names[$axis],$level,$current->[1],$previous_level,$previous->[1]
+ ) if($previous->[1] > 0 && $current->[1] < ($previous->[1]*$minimum_ratio));
+ return undef;
+}
+
+sub critical_shadow_needs_revisit {
+ my ($step,$converged)=@_;
+ return 0 if($converged || ref($step) ne "HASH");
+ my $ire=defined($step->{ire}) && looks_like_number($step->{ire})
+  ? ($step->{ire}+0)
+  : (defined($step->{stimulus}) && looks_like_number($step->{stimulus}) ? ($step->{stimulus}+0) : undef);
+ return 0 if(!defined($ire));
+ return abs($ire-2.3) < 0.001 ? 1 : 0;
+}
+
+# Resolve the dE target used by a specialised solver.  The worker-specific key
+# remains available as an intentional expert override, but normal AutoCal runs
+# must inherit the operator's target_delta_e rather than silently reverting to
+# a solver-local default.
+sub autocal_solver_target_delta_e {
+ my ($config,$override_key,$fallback)=@_;
+ $fallback=0.5 if(!defined($fallback) || !looks_like_number($fallback) || $fallback <= 0);
+ my $target=$fallback+0;
+ if(ref($config) eq "HASH") {
+  if(defined($override_key) && $override_key ne ""
+   && defined($config->{$override_key}) && looks_like_number($config->{$override_key})
+   && ($config->{$override_key}+0) > 0) {
+   $target=$config->{$override_key}+0;
+  } elsif(defined($config->{target_delta_e}) && looks_like_number($config->{target_delta_e})
+   && ($config->{target_delta_e}+0) > 0) {
+   $target=$config->{target_delta_e}+0;
+  }
+ }
+ $target=0.05 if($target < 0.05);
+ $target=10.0 if($target > 10.0);
+ return $target+0;
+}
+
+# A small white-channel residual is not, by itself, permission to abandon an
+# above-target solve.  Allow the noise/physical-limit shortcut only after the
+# worker has made several real attempts, or after repeated reverts demonstrate
+# that those attempts are no longer improving the result.
+sub autocal_white_residual_stop_allowed {
+ my ($iter,$reverts,$residual,$de,$target)=@_;
+ return 0 if(!defined($residual) || !looks_like_number($residual));
+ return 0 if(!defined($de) || !looks_like_number($de));
+ return 0 if(!defined($target) || !looks_like_number($target) || $target <= 0);
+ return 0 if(($de+0) <= ($target+0));
+ return 0 if(($residual+0) > 0.004);
+ $iter=0 if(!defined($iter) || !looks_like_number($iter));
+ $reverts=0 if(!defined($reverts) || !looks_like_number($reverts));
+ return (($iter+0) >= 4 || ($reverts+0) >= 2) ? 1 : 0;
+}
+
+# A historically sub-target sample is not enough to finish an anchor when the
+# coefficients that produced it are restored and their verification read has
+# drifted back above target.  Continue solving from that verified panel state;
+# a failed verification read cannot safely drive another move and is handled by
+# the caller's existing read-failure/best-known fallback.
+sub autocal_restored_acceptance_needs_retry {
+ my ($restored_ok,$restored_de,$target)=@_;
+ return 0 if(!$restored_ok);
+ return 0 if(!defined($restored_de) || !looks_like_number($restored_de));
+ return 0 if(!defined($target) || !looks_like_number($target) || ($target+0) <= 0);
+ return (($restored_de+0) >= ($target+0)) ? 1 : 0;
+}
+
+1;

--- a/usr/share/PGenerator/lg.pm
+++ b/usr/share/PGenerator/lg.pm
@@ -318,98 +318,6 @@ sub lg_cec_status (@) {
  return &lg_decode_json($raw);
 }
 
-###############################################
-#        TV Power Gate (CEC-backed)           #
-###############################################
-# A powered-off LG panel does not refuse TCP connections, it silently drops
-# the SYNs, so a helper spawn against it runs to its outer "timeout Ns"
-# wrapper instead of failing fast. Those spawns are synchronous backticks
-# (lg_helper_run) executed on the daemon's single WebUI request thread, so
-# each one freezes the entire WebUI for the full wrapper. The read-only state
-# polls are the common case -- the AutoCal panels re-sync every ~30s whether
-# or not anyone is calibrating -- so we short-circuit those when CEC already
-# knows the panel is in standby.
-#
-# Everything here FAILS OPEN. A missing, stale, unparseable or "unknown"
-# reading, no CEC on this box, or a calibration in flight all fall through to
-# the normal helper path. A CEC problem must never make a reachable TV look
-# unreachable.
-
-# CEC power state is cached in a file by the WebUI's own /api/cec/status path
-# (webui_cec_power_cache_write). We read the FILE rather than webui.pm's
-# $_cec_cache / $_cec_last_power_query lexicals on purpose: those are plain
-# "my" variables, so under Perl ithreads any handler running on a different
-# thread gets its own private copy and the reading silently vanishes. The
-# file is the only representation shared across threads.
-$LG_CEC_POWER_CACHE_FILE="/tmp/pgenerator-cec-power.json";
-# Oldest reading we will gate on. The CEC status path refreshes the file at
-# most once per $_CEC_POWER_QUERY_THROTTLE (15s) while a browser is polling;
-# beyond this we treat it as stale and let the request through.
-$LG_TV_OFF_GATE_MAX_AGE=90;
-
-sub lg_cec_power_state_cached (@) {
- my $max_age=shift;
- $max_age=$LG_TV_OFF_GATE_MAX_AGE if(!defined($max_age) || $max_age <= 0);
- return "" if(!-f $LG_CEC_POWER_CACHE_FILE);
- my $mtime=(stat($LG_CEC_POWER_CACHE_FILE))[9]||0;
- return "" if(!$mtime);
- return "" if((time() - $mtime) > $max_age);
- my $json="";
- if(open(my $fh,"<",$LG_CEC_POWER_CACHE_FILE)) { local $/; $json=<$fh>; close($fh); }
- return "" if(!defined($json) || $json eq "");
- my ($power)=($json =~ /"tv_power"\s*:\s*"([^"]*)"/);
- return "" if(!defined($power));
- $power=lc($power);
- $power=~s/^\s+//;
- $power=~s/\s+$//;
- return $power;
-}
-
-sub lg_calibration_run_active (@) {
- # Never gate while a calibration or meter run is in flight: those paths
- # drive the TV themselves and may legitimately be mid-wake, and a stale
- # CEC reading must not be allowed to interrupt them.
- foreach my $state_file ("/tmp/meter_lg_autocal.json","/tmp/meter_lg_3d_autocal.json") {
-  next if(!-f $state_file);
-  my $json="";
-  if(open(my $fh,"<",$state_file)) { local $/; $json=<$fh>; close($fh); }
-  next if(!defined($json) || $json eq "");
-  return 1 if($json=~/"status"\s*:\s*"running"/);
- }
- # An open meter session means a read is in progress or imminent.
- return 1 if(-f "/tmp/meter_session.pid");
- return 0;
-}
-
-sub lg_tv_powered_off (@) {
- # True ONLY on a fresh, unambiguous "the panel is in standby" reading.
- # "powering-on"/"powering-off" are transitional -- the TV may answer at any
- # moment -- so they are deliberately not gated.
- my $power=&lg_cec_power_state_cached();
- return 0 if($power eq "");
- return 1 if($power eq "standby" || $power eq "off");
- return 0;
-}
-
-sub lg_tv_off_gate (@) {
- # Returns an error hashref to short-circuit a READ-ONLY state poll, or
- # undef to proceed exactly as before. Callers must only use this for polls
- # that merely observe TV state. Control actions (wake/power, pairing, input
- # switching) and the whole calibration path must never be gated: those are
- # user-initiated and are allowed to spend the time, and some of them are
- # what turns the TV back on.
- my $what=shift;
- $what="read TV state" if(!defined($what) || $what eq "");
- return undef if(&lg_calibration_run_active());
- return undef if(!&lg_tv_powered_off());
- return {
-  status   => "error",
-  message  => "LG TV is powered off (CEC reports standby). Turn the TV on to $what.",
-  tv_off   => &lg_json_true(),
-  tv_power => "standby",
- };
-}
-
 sub lg_detect_from_cec (@) {
  my $cec=shift;
  return 0 if(ref($cec) ne "HASH");
@@ -998,6 +906,12 @@ sub lg_helper_run (@) {
  my $payload=MIME::Base64::encode_base64(&lg_encode_json($request),"");
  my $timeout=&lg_helper_timeout($request);
  my $cmd="timeout ${timeout}s env PGEN_LG_REQUEST_B64=".&lg_shell_quote($payload)." ".&lg_shell_quote($helper)." 2>&1";
+ # Synchronous backtick. Routes that are not concurrent-safe run on the general
+ # WebUI lane, which is a single serialized worker ($WEBUI_WORKER_POOL_SIZE=1
+ # in webui.pm), so on those paths $timeout is not just this request's budget
+ # -- it is how long every other unsafe route waits. Treat the values in
+ # lg_helper_timeout as a WebUI-availability budget, not merely a patience
+ # setting, and prefer an explicit short helper_timeout on read-only polls.
  my $raw=`$cmd`;
  my $exit_status=$? >> 8;
  my $result=&lg_decode_json($raw);
@@ -1015,6 +929,19 @@ sub lg_helper_run (@) {
  return { status => "error", message => $raw };
 }
 
+# Why these budgets are large, and why shrinking them blindly is unsafe:
+# a powered-off LG panel does not refuse TCP connections, it silently drops
+# the SYNs. So an unreachable TV never fails fast on its own -- without the
+# connect bounding in pgenerator-lg (connect_timeout_for/$MAX_CONNECT_TIMEOUT
+# and reap_child_bounded) a spawn parked for the kernel's SYN-retry budget,
+# ~127s, regardless of any "5 second connect timeout" in the helper. With that
+# bounding in place an unreachable panel now costs roughly 20s per spawn as
+# the helper exhausts its wss/ws candidates, and the wrappers below are only
+# reached when TCP completes but the session then stalls mid-handshake.
+#
+# The values are therefore sized for a slow *reachable* TV completing real
+# work, not for detecting an absent one. Callers that cannot afford to wait
+# should pass an explicit helper_timeout rather than lowering these.
 sub lg_helper_timeout (@) {
  my $request=shift;
  $request={} if(ref($request) ne "HASH");
@@ -1633,15 +1560,24 @@ sub webui_lg_picture_settings (@) {
  my $ignore_calibration_picture_mode=$payload->{"ignore_calibration_picture_mode"} ? 1 : 0;
  my $picture_mode=$payload->{"picture_mode"}||"";
  $picture_mode=$clients->{"calibration_picture_mode"}||"" if($picture_mode eq "" && !$ignore_calibration_picture_mode);
-# Read-only poll: if CEC already knows the panel is in standby there is
-# nothing to read, and spawning the helper would burn the full 60s
-# picture_get wrapper on the daemon's single WebUI request thread. The
-# AutoCal panels re-poll this endpoint every ~30s whether or not anyone is
-# calibrating, so with the TV off the WebUI spent most of its life frozen
-# behind this one call. Fails open in every ambiguous case -- and is never
-# applied to the picture_set / calibration paths below. See lg_tv_off_gate.
-my $tv_off_gate=&lg_tv_off_gate("read picture settings");
-return &lg_encode_json($tv_off_gate) if(ref($tv_off_gate) eq "HASH");
+# CEC power is advisory and can be stale or unknown while WebOS is reachable.
+# Let the bounded helper request below determine whether the TV can be read.
+#
+# Bound that request tightly, though. This is a read-only poll and it runs on
+# the general WebUI lane, which is a single serialized worker
+# ($WEBUI_WORKER_POOL_SIZE=1 in webui.pm), and lg_helper_run is a synchronous
+# backtick -- so every second spent here is a second no other unsafe route can
+# be served. A powered-off panel does not refuse TCP, it silently drops the
+# SYNs, so the helper walks its connect candidates to exhaustion (~20s) rather
+# than failing fast, and the default picture_get budget of 60s is worse still.
+# A healthy read answers in well under a second.
+#
+# Every browser caller already abandons the fetch on its own timeout (7-18s),
+# so helper work beyond that budget can never reach anyone -- capping it here
+# discards only results that were guaranteed to be thrown away. Callers that
+# need a longer budget say so explicitly; the AutoCal worker sends 90.
+my $helper_timeout=int($payload->{"helper_timeout"}||0);
+$helper_timeout=8 if($helper_timeout <= 0);
 &lg_calmode_trace("picture_get: force_ddc=".($payload->{"force_ddc_white_balance"}?1:0)." pmode=$picture_mode"); # TEMP DEBUG CALMODE
 my $result=&lg_helper_run({
  action => "picture_get",
@@ -1652,7 +1588,7 @@ my $result=&lg_helper_run({
 	  signal_mode => $payload->{"signal_mode"}||"",
 	  tv_input => &lg_input_from_cec(),
 	  force_ddc_white_balance => $payload->{"force_ddc_white_balance"} ? &lg_json_true() : &lg_json_false(),
-	  helper_timeout => int($payload->{"helper_timeout"}||0),
+	  helper_timeout => $helper_timeout,
 	  connect_timeout => 5,
 	 });
  &lg_update_connect_metadata($result,$clients->{"manual_ip"} || $ip) if(($result->{"status"}||"") eq "ok");
@@ -4174,7 +4110,7 @@ async function lgDisplayControlRefresh(force){
   const r=await fetchJSON('/api/lg/picture-settings',{
    method:'POST',
    headers:{'Content-Type':'application/json'},
-   body:JSON.stringify({keys:['pictureMode',...LG_DISPLAY_CONTROL_KEYS],picture_mode:lgDisplayControlPictureMode(),signal_mode:lgSignalModeKey(),ignore_calibration_picture_mode:true}),
+   body:JSON.stringify({keys:['pictureMode',...LG_DISPLAY_CONTROL_KEYS],picture_mode:lgDisplayControlPictureMode(),signal_mode:lgSignalModeKey(),ignore_calibration_picture_mode:true,helper_timeout:16}),
    _quiet:true,
    _timeoutMs:18000
   });

--- a/usr/share/PGenerator/webui.pm
+++ b/usr/share/PGenerator/webui.pm
@@ -6301,6 +6301,7 @@ sub webui_meter_settings_save (@) {
     low_light_enabled low_light_mode low_light_trigger
   grey_two_point_low grey_two_point_high
   grey_ref_mode gray_world rgb_formula de_form color_de_form target_gamma
+  target_white_use_measured target_white_level target_black_use_measured target_black_level
   target_white_x target_white_y custom_d65_enabled
   hdr_bt2390 hdr_diffuse_white hdr_diffuse_white_auto incl_lum sep_lum color_incl_lum simulate_spectro
  );
@@ -28462,6 +28463,10 @@ function meterSetTargetLevels(){
   black:{useMeasured:bUseMeasured,value:bValue,overridden:bOver}
  };
  try{ localStorage.setItem(METER_TARGET_LEVELS_KEY,JSON.stringify(state)); }catch(e){}
+ // Target levels must also be shared by every browser and survive a daemon
+ // restart. The server settings payload is authoritative; localStorage is
+ // retained only as a warm-start fallback while the settings request loads.
+ try{ if(meterSettingsLoaded&&typeof saveMeterSettings==='function') saveMeterSettings(); }catch(e){}
  // Let the checkbox/input state paint before recalculating charts. Rapid
  // toggles coalesce into one refresh instead of stacking expensive canvases.
  try{ meterScheduleTargetCurveRefresh(); }catch(e){}
@@ -38991,7 +38996,45 @@ async function meterAutoCalApplyStatus(status){
 	  const completed=new Set(meterReadings.filter(r=>r&&r.luminance!=null).map(r=>meterStepNameKey(r)));
   const sorted=[...meterReadings].sort((a,b)=>(a.ire||0)-(b.ire||0));
 	  if(sorted.length) {
-	   drawAllCharts(sorted);
+	   // AutoCal status is polled every 1.5s, but most polls only update the
+	   // current iteration/progress text. Repainting all five canvases and
+	   // serialising the whole series cache on every unchanged poll blocks the
+	   // browser's main thread and makes the rest of the UI visibly judder.
+	   //
+	   // Track only inputs which affect the greyscale charts. During a running
+	   // pass, use the same frame-budgeted painter as an ordinary greyscale
+	   // series. A terminal status always cancels queued work and performs one
+	   // synchronous final paint so the completed charts cannot be left on a
+	   // mixture of two status revisions.
+	   const statusRunning=String(status.status||'').toLowerCase()==='running';
+	   const chartSignature=JSON.stringify([
+	    sorted.map(rd=>[
+	     meterStepNameKey(rd),
+	     rd.luminance,rd.X,rd.Y,rd.Z,
+	     rd.target_x,rd.target_y,rd.target_Yn,rd.target_luminance,
+	     rd.series_target_white_y,rd.lg_target_white_y,rd.autocal_white_y,
+	     rd.series_target_black_y,rd.best_known_delta_e
+	    ]),
+	    Number.isFinite(chartWhiteY)?chartWhiteY:null,
+	    status.target_gamma||meterActiveSeriesTargetGamma||'',
+	    status.signal_mode||meterActiveSeriesSignalMode||'',
+	    status.ddc_layout||''
+	   ]);
+	   const chartChanged=sorted.length!==meterLastChartCount||chartSignature!==meterLastChartSignature;
+	   if(statusRunning){
+	    if(chartChanged){
+	     meterLastChartCount=sorted.length;
+	     meterLastChartSignature=chartSignature;
+	     meterQueueRunningGreyscaleChartRefresh(sorted);
+	     meterCacheSeriesState(status.status||'running');
+	    }
+	   }else{
+	    meterCancelRunningGreyscaleChartRefresh();
+	    meterLastChartCount=sorted.length;
+	    meterLastChartSignature=chartSignature;
+	    drawAllCharts(sorted);
+	    meterCacheSeriesState(status.status||'complete');
+	   }
 	   const currentValid=currentKey?meterReadings.find(rd=>rd&&rd.luminance!=null&&meterStepNameKey(rd)===currentKey):null;
 	   // meterReadings is sorted by IRE (see meterAutoCalStatusChartReadings),
 	   // NOT by measurement order, so reverse().find() returned the HIGHEST-IRE
@@ -39008,7 +39051,6 @@ async function meterAutoCalApplyStatus(status){
 	    });
 	   }
 	   if(lastValid) updateLiveReading(lastValid);
-	   meterCacheSeriesState(status.status||'running');
 	  }
   if(meterSeriesSteps){
    const sortedSteps=meterGreyscaleSeriesSteps(meterSeriesSteps);
@@ -41403,6 +41445,11 @@ function meterFullAutoCalTouchupTargetY(){
     lg_extended_sdr_16_255:meterLgAutoCalUsesExtendedSdr(),
     ...meterPatternInsertionPayload(),
     target_delta_e:target,
+    // Send the target redundantly under the specialised worker keys as well.
+    // New workers inherit target_delta_e directly; these explicit values keep
+    // older HDR/DV and SDR DPG workers from silently falling back to 0.5.
+    lg_autocal_hdr20_dpg_target_de:target,
+    lg_autocal_sdr26_dpg_target_de:target,
     delta_e_formula:deltaEFormula,
     target_luminance:targetY,
     setup_luminance_reference:(Number.isFinite(setupY)&&setupY>0)?setupY:undefined,
@@ -41573,6 +41620,8 @@ async function meterFullAutoCalStartTouchup(lutStatus){
     lg_extended_sdr_16_255:meterLgAutoCalUsesExtendedSdr(),
     ...meterPatternInsertionPayload(),
     target_delta_e:target,
+    lg_autocal_hdr20_dpg_target_de:target,
+    lg_autocal_sdr26_dpg_target_de:target,
     delta_e_formula:deltaEFormula,
     target_luminance:targetY,
     setup_luminance_reference:(Number.isFinite(setupY)&&setupY>0)?setupY:undefined,
@@ -42547,7 +42596,9 @@ async function meterAutoCalConfirmAndStart(){
     lg_autocal_26_anchor_predrive:false,
     lg_extended_sdr_16_255:meterLgAutoCalUsesExtendedSdr(),
     ...meterPatternInsertionPayload(),
-    target_delta_e:target,
+	    target_delta_e:target,
+	    lg_autocal_hdr20_dpg_target_de:target,
+	    lg_autocal_sdr26_dpg_target_de:target,
     delta_e_formula:deltaEFormula,
     target_luminance:hdrWorkflow?undefined:targetY,
     setup_luminance_reference:hdrWorkflow?undefined:setupY,
@@ -52983,6 +53034,10 @@ function saveMeterSettings(){
   color_de_form:val('meterColorDeltaEForm','de2000'),
     color_incl_lum:chk('meterColorIncludeLumError'),
   target_gamma:val('meterTargetGamma'),
+  target_white_use_measured:chk('meterTargetWhiteUseMeasured'),
+  target_white_level:chk('meterTargetWhiteUseMeasured')?null:(val('meterTargetWhite')||null),
+  target_black_use_measured:chk('meterTargetBlackUseMeasured'),
+  target_black_level:chk('meterTargetBlackUseMeasured')?null:(val('meterTargetBlack')||null),
     custom_d65_enabled:chk('meterCustomD65Enabled'),
     target_white_x:val('meterTargetWhiteX'),
     target_white_y:val('meterTargetWhiteY'),
@@ -53197,6 +53252,13 @@ async function loadMeterSettings(){
  // ST 2084 never survives into SDR.
  try{ if(typeof meterSyncTargetGammaOptionsForSignal==='function') meterSyncTargetGammaOptionsForSignal(); }catch(e){}
  meterSyncTargetGammaControl();
+ if(s.target_white_use_measured!=null||s.target_white_level!=null||s.target_black_use_measured!=null||s.target_black_level!=null){
+  setChk('meterTargetWhiteUseMeasured',s.target_white_use_measured==null?true:s.target_white_use_measured);
+  setVal('meterTargetWhite',s.target_white_level==null?'':String(s.target_white_level));
+  setChk('meterTargetBlackUseMeasured',s.target_black_use_measured==null?!meterDisplayTypeIsOledClass():s.target_black_use_measured);
+  setVal('meterTargetBlack',s.target_black_level==null?'':String(s.target_black_level));
+  meterSetTargetLevels();
+ }
  setChk('meterCustomD65Enabled', s.custom_d65_enabled);
  setVal('meterTargetWhiteX', s.target_white_x);
  setVal('meterTargetWhiteY', s.target_white_y);

--- a/usr/share/PGenerator/webui.pm
+++ b/usr/share/PGenerator/webui.pm
@@ -5408,31 +5408,13 @@ sub webui_meter_lg_autocal_start (@) {
   return '{"status":"error","message":"LG Auto Cal is already running"}';
  }
  return '{"status":"error","message":"LG 3D LUT AutoCal is already running"}' if(&webui_meter_lg_3d_autocal_running());
- # Final server-side power gate immediately before any meter/session teardown
- # or worker launch. The browser's LG status is only a pairing snapshot and
- # can still say "connected" after the panel has entered standby. Use the
- # fresh CEC-backed LG status here so direct API callers and stale browser
- # tabs cannot launch AutoCal unless the display is definitely on.
- if(defined(&lg_cec_status)) {
-  my $tv_status=eval { &lg_cec_status() };
-  if(ref($tv_status) eq "HASH") {
-   my $power=lc($tv_status->{"tv_power"}||"");
-   $power=~s/^\s+|\s+$//g;
-   if($power eq "standby" || $power eq "off" || $power eq "powering-off") {
-    return '{"status":"error","message":"LG TV is powered off. Turn it on and wait for it to finish starting before Auto Cal."}';
-   }
-   if($power eq "powering-on") {
-    return '{"status":"error","message":"LG TV is still starting. Wait until it is fully on before Auto Cal."}';
-   }
-   if($power ne "on") {
-    return '{"status":"error","message":"Unable to verify that the LG TV is powered on. Turn it on, wait for CEC to report On, then try Auto Cal again."}';
-   }
-  } else {
-   return '{"status":"error","message":"Unable to verify that the LG TV is powered on. Turn it on, wait for CEC to report On, then try Auto Cal again."}';
-  }
- } else {
-  return '{"status":"error","message":"Unable to verify LG TV power before Auto Cal."}';
- }
+ # CEC power is advisory: valid WebOS sessions can coexist with unknown or
+ # stale CEC state, so nothing here refuses a launch on a CEC reading.
+ # Consequence worth stating plainly: the teardown below and the worker launch
+ # now happen before anything has established the panel is reachable. The
+ # worker's initial picture-settings read is the reachability authority, so an
+ # unreachable TV costs the meter session first and reports the failure a few
+ # minutes later, rather than failing at this boundary.
  &webui_meter_stop();
  # Drop any stale stop file before launch. A root-owned leftover in sticky
  # /tmp cannot be unlinked by the pgenerator webui user, and the worker
@@ -5772,6 +5754,60 @@ sub webui_meter_lg_3d_autocal_same_run_running (@) {
  return 0;
 }
 
+# A completed Full AutoCal stage is a one-shot operation.  Its start handler
+# calls webui_meter_stop() before launching the worker, so replaying an old
+# greyscale completion is not harmless: it cancels any post-cal report series
+# currently using the meter and can upload another LUT to the TV.  Keep the
+# matching predicates pure so the safety contract is directly testable.
+sub webui_meter_lg_3d_autocal_completed_state_matches (@) {
+ my ($state,$run)=@_;
+ return 0 if(ref($state) ne "HASH" || !defined($run) || $run eq "");
+ return 0 if(lc($state->{"status"}||"") ne "complete" || !$state->{"upload_verified"});
+ my @runs=grep { defined($_) && !ref($_) && $_ ne "" } ($state->{"full_autocal_run_id"},$state->{"run_id"});
+ return scalar(grep { $_ eq $run } @runs) ? 1 : 0;
+}
+
+sub webui_meter_lg_3d_autocal_completed_report_matches (@) {
+ my ($archive,$run)=@_;
+ return 0 if(ref($archive) ne "HASH" || !defined($run) || $run eq "");
+ my $report=(ref($archive->{"report"}) eq "HASH") ? $archive->{"report"} : {};
+ my $archive_run=$archive->{"run_id"} || $report->{"run_id"} || "";
+ return 0 if(ref($archive_run) || $archive_run ne $run);
+ my $completion=(ref($report->{"completion_status"}) eq "HASH") ? $report->{"completion_status"} : {};
+ return 0 if(lc($completion->{"status"}||"") ne "complete");
+ return ($completion->{"full_workflow"} || $completion->{"full_autocal"}) ? 1 : 0;
+}
+
+sub webui_meter_lg_3d_autocal_full_run_already_complete (@) {
+ my ($body)=@_;
+ my $payload=eval { require JSON::PP; JSON::PP::decode_json($body||""); };
+ return 0 if(ref($payload) ne "HASH" || !$payload->{"full_workflow"});
+ my $run=$payload->{"full_autocal_run_id"} || $payload->{"run_id"} || "";
+ return 0 if(ref($run) || $run!~/\A[A-Za-z0-9._-]{1,200}\z/);
+
+ # Before /api/lg/autocal/run/end strips the workflow metadata, the terminal
+ # worker state is the quickest receipt and also protects the touch-up gap.
+ if(-f $_meter_lg_3d_autocal_file) {
+  my $json="";
+  if(open(my $fh,"<",$_meter_lg_3d_autocal_file)) { local $/; $json=<$fh>; close($fh); }
+  my $state=eval { JSON::PP::decode_json($json||""); };
+  return 1 if(&webui_meter_lg_3d_autocal_completed_state_matches($state,$run));
+ }
+
+ # The report archive survives that metadata cleanup and is atomically
+ # replaced throughout the optional post-cal reads.  completion_status stays
+ # present in every later archive stage, making it the durable replay guard.
+ foreach my $dir ("/var/lib/PGenerator/reports/full-autocal","/tmp/PGenerator_full_autocal_reports") {
+  my $file="$dir/$run.json";
+  next if(!-f $file);
+  my $json="";
+  if(open(my $fh,"<",$file)) { local $/; $json=<$fh>; close($fh); }
+  my $archive=eval { JSON::PP::decode_json($json||""); };
+  return 1 if(&webui_meter_lg_3d_autocal_completed_report_matches($archive,$run));
+ }
+ return 0;
+}
+
 sub webui_meter_lg_3d_autocal_mark_cancelled (@) {
  return unless(-f $_meter_lg_3d_autocal_file);
  my $json="";
@@ -5811,6 +5847,10 @@ sub webui_meter_lg_3d_autocal_start (@) {
  return '{"status":"error","message":"LG 3D LUT AutoCal payload required"}' if(!defined($body) || $body eq "" || $body!~/^\s*\{/);
  $body=&webui_meter_autocal_force_standard_observer($body);
  $body=&webui_meter_lg_body_with_display_model($body);
+ # Reject a stale browser's same-run replay before webui_meter_stop() can
+ # cancel an active report series or the worker can write the panel again.
+ return '{"status":"error","message":"This Full AutoCal run has already completed its 3D LUT stage","already_complete":true}'
+  if(&webui_meter_lg_3d_autocal_full_run_already_complete($body));
  return '{"status":"error","message":"LG Auto Cal is already running"}' if(&webui_meter_lg_autocal_running());
  if(&webui_meter_lg_3d_autocal_running()) {
   return '{"status":"started","message":"LG 3D LUT AutoCal already running"}' if(&webui_meter_lg_3d_autocal_same_run_running($body));
@@ -37979,7 +38019,7 @@ async function meterAutoCalLoadClipControls(){
  const r=await fetchJSON('/api/lg/picture-settings',{
   method:'POST',
   headers:{'Content-Type':'application/json'},
-  body:JSON.stringify({keys:['pictureMode','brightness','contrast'],picture_mode:meterLgPictureModeValue()}),
+  body:JSON.stringify({keys:['pictureMode','brightness','contrast'],picture_mode:meterLgPictureModeValue(),helper_timeout:8}),
   _quiet:true,
   _timeoutMs:10000
  });
@@ -39959,9 +39999,15 @@ function meterFullAutoCalMergeCleanupConfigFromStatus(status){
 }
 
 function meterFullAutoCalEnsureStatusPhase(status,phase){
- if(meterFullAutoCalRunning&&meterFullAutoCalPhase===phase) return true;
- if(status&&status.full_workflow&&!meterFullAutoCalStatusMatchesRun(status)) return false;
+ // A saved browser phase is not authority. A stale tab/device can retain
+ // first-greyscale long after the backend has advanced or cleared the run;
+ // trusting it here replayed that completed result and launched another 3D
+ // LUT while the real session was measuring its post-cal report.
+ const currentPhase=String(meterFullAutoCalPhase||'');
+ if(currentPhase==='precal-report'||currentPhase==='postcal-report') return false;
  if(!(status&&status.full_workflow&&meterFullAutoCalStatusPhase(status)===phase)) return false;
+ if(!meterFullAutoCalStatusMatchesRun(status)) return false;
+ if(meterFullAutoCalRunning&&currentPhase===phase) return true;
  // Never re-adopt a terminal full-workflow status from a fresh browser
  // (Stop + refresh left status=complete + full_workflow on the 3D file and
  // this would open the Generate Post-Cal Report popup). Mid-session
@@ -40726,7 +40772,6 @@ async function meterStartFullAutoCal(){
  if(meterActionPending||meterAutoCalRunning||meterLg3dAutoCalRunning||meterFullAutoCalRunning){toast('Meter operation already in progress',true);return;}
  if(!(await meterEnsureDetected())){toast('No meter detected',true);return;}
  if(!meterFullAutoCalAvailable()){toast('Connect an LG TV before starting Full Auto Cal',true);return;}
- if(!(await meterEnsureLgTvReadyForAutoCal('Full Auto Cal'))) return;
  if(!(await meterEnsureLgAutoCalTransport('Full Auto Cal'))) return;
  if(!meterEnsureLgAutoCalExtendedVideoTransport()) return;
  if(!meterEnsureAppliedGeneratorSettings()) return;
@@ -40879,7 +40924,7 @@ async function meterStartFullAutoCal(){
 }
 
 async function meterFullAutoCalStart3d(firstStatus){
- if(!meterFullAutoCalRunning) return;
+ if(!meterFullAutoCalRunning||meterFullAutoCalPhase!=='first-greyscale') return false;
  meterFullAutoCalResults.first=firstStatus||null;
  const firstRunId=firstStatus&&(firstStatus.full_autocal_run_id||firstStatus.run_id);
  if(firstRunId) meterFullAutoCalRunId=firstRunId;
@@ -41023,7 +41068,7 @@ async function meterFullAutoCalAdvancePastGreyscale(status){
 // meterStartFullAutoCal before greyscale started) and stays Relative through
 // this stage.
 async function meterDvAutoCalStartProfile(firstStatus){
- if(!meterFullAutoCalRunning) return;
+ if(!meterFullAutoCalRunning||meterFullAutoCalPhase!=='first-greyscale') return false;
  meterFullAutoCalResults.first=firstStatus||null;
  const firstRunId=firstStatus&&(firstStatus.full_autocal_run_id||firstStatus.run_id);
  if(firstRunId) meterFullAutoCalRunId=firstRunId;
@@ -41856,38 +41901,6 @@ async function meterAutoCalBackendRecoveryWatchdog(){
  }
 }
 
-// Confirm the display is actually awake before entering the AutoCal wizard or
-// launching its worker. LG's `connected` flag means a saved WebOS pairing is
-// available; it is not a live power check and remains true while the TV is in
-// standby. AutoCal requires a definite CEC `on` state. Retry transient unknown
-// readings briefly, then fail closed; the server and worker repeat the gate at
-// the launch boundary.
-async function meterEnsureLgTvReadyForAutoCal(label){
- let status=null;
- let power='';
- for(let attempt=0;attempt<3;attempt++){
-  try{
-   status=await fetchJSON('/api/cec/status',{_quiet:true,_timeoutMs:5000});
-  }catch(e){ status=null; }
-  power=String((status&&status.tv_power)||'').trim().toLowerCase();
-  if(power==='on'||power==='standby'||power==='off'||power==='powering-off'||power==='powering-on') break;
-  if(attempt<2) await new Promise(resolve=>setTimeout(resolve,1000));
- }
- if(power==='standby'||power==='off'||power==='powering-off'){
-  toast('LG TV is powered off. Turn it on and wait for it to finish starting before '+(label||'Auto Cal')+'.',true);
-  return false;
- }
- if(power==='powering-on'){
-  toast('LG TV is still starting. Wait until it is fully on before '+(label||'Auto Cal')+'.',true);
-  return false;
- }
- if(power!=='on'){
-  toast('Unable to verify that the LG TV is powered on. Turn it on, wait for CEC to report On, then try '+(label||'Auto Cal')+' again.',true);
-  return false;
- }
- return true;
-}
-
 async function meterAutoCalInitialRecoveryPoll(){
  if(meterFullAutoCalReportPhaseActive()) return;
  if(meterAutoCalSetupOverlayActive()||meterAutoCalRunning||meterAutoCalPolling||meterActionPending||meterLg3dAutoCalRunning||meterLg3dAutoCalPolling) return;
@@ -41922,7 +41935,14 @@ async function meterStartAutoCal(options){
   meterSetActiveSeriesChartContext();
  }
 	 if(!meterAutoCalAvailable()) return fail(fullWorkflow?'Connect an LG TV before starting Full Auto Cal':'Connect an LG TV and select Greyscale LG 26pt AutoCal first');
-	 if(!(await meterEnsureLgTvReadyForAutoCal(fullWorkflow?'Full Auto Cal':'LG Greyscale Auto Cal'))) return fail('');
+	 // CEC stays available as status and manual control, but no longer gates
+	 // launch. Be clear about what that leaves, because it is easy to misread
+	 // the calls below as checks: meterAutoCalAvailable() above is a pairing
+	 // snapshot rather than a liveness test, and both transport preflights
+	 // below have been unconditional `return true` since 2026-06-13. So the
+	 // browser no longer verifies the panel is awake at all. The worker's
+	 // initial picture-settings read is the only reachability authority, and
+	 // it surfaces failure minutes in -- after the meter session is torn down.
 	 meterAutoCalWizardContextActive=true;
 	 if(!(await meterEnsureLgAutoCalTransport(fullWorkflow?'Full Auto Cal':'LG Greyscale Auto Cal'))) return fail('');
 	 if(!meterEnsureLgAutoCalExtendedVideoTransport()) return fail('');
@@ -43862,6 +43882,22 @@ refresh_rate:getMeterRefreshRate()||undefined,
    if(!fullWorkflow||!meterFullAutoCalTransitionBusy(r&&r.message)) break;
    meterSetWorkflowProgress({status:'running',current_step:0,total_steps:1,current_name:'Waiting for greyscale AutoCal cleanup'},{workflow:'full',label:'Waiting for greyscale AutoCal cleanup'});
    await new Promise(resolve=>setTimeout(resolve,900+(attempt*400)));
+   }
+   if(r&&r.already_complete){
+    // A stale browser tried to replay a terminal Full AutoCal stage. The
+    // server rejected it before touching the shared meter or TV; retire only
+    // this browser's stale workflow state and do not run the normal retry /
+    // abort path (which would send CAL_END and /autocal/run/end itself).
+    meterLg3dAutoCalRunning=false;
+    meterActionPending=false;
+    meterHideWorkflowProgress();
+    if(meterLg3dAutoCalSpectroSetupActive){
+     meterLg3dAutoCalSpectroSetupActive=false;
+     meterSpectroSetupApply(null);
+    }
+    if(fullWorkflow) meterFullAutoCalResetState(true);
+    toast(r.message||'This Full AutoCal 3D LUT stage is already complete');
+    return 'already-complete';
    }
    if(!r||r.status!=='started'){
     // The start handler always spawns the worker before returning 'started',

--- a/usr/share/PGenerator/webui.pm
+++ b/usr/share/PGenerator/webui.pm
@@ -11794,7 +11794,12 @@ body.meter-autocal-active .meter-autocal-mask{display:flex}
 .meter-workflow-progress-fill{height:100%;width:0;min-width:0;background:linear-gradient(90deg,#5d6dff 0%,#4d8df7 45%,#39d06f 100%);box-shadow:0 0 12px rgba(76,175,80,.35),inset 0 1px 0 rgba(255,255,255,.24);transition:width .28s ease,min-width .18s ease;position:relative;overflow:hidden;border-radius:3px}
 .meter-workflow-progress-fill.active{min-width:10px}
 .meter-workflow-progress-fill.active::after{content:"";position:absolute;inset:-40% -25%;background:linear-gradient(105deg,transparent 0%,rgba(255,255,255,.06) 34%,rgba(255,255,255,.46) 50%,rgba(255,255,255,.06) 66%,transparent 100%);transform:translateX(-115%);animation:meterProgressShimmer 1.65s ease-in-out infinite}
-@media(max-width:720px){.meter-workflow-progress-wrap{grid-template-columns:minmax(0,1fr) auto}.meter-workflow-progress{grid-column:1 / -1;grid-row:2}}
+.meter-lut-calculation-progress{display:grid;grid-template-columns:minmax(260px,.9fr) minmax(180px,2fr) auto;align-items:center;gap:10px;margin:0 0 8px;color:var(--text2);font-size:.68rem}
+.meter-lut-calculation-label{overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.meter-lut-calculation-count{font-variant-numeric:tabular-nums;white-space:nowrap}
+.meter-lut-calculation-bar{height:6px;border-radius:999px;background:#0d0f18;border:1px solid rgba(255,255,255,.12);overflow:hidden}
+.meter-lut-calculation-fill{height:100%;width:0;background:linear-gradient(90deg,#5d6dff,#4d8df7);transition:width .2s ease}
+@media(max-width:720px){.meter-workflow-progress-wrap{grid-template-columns:minmax(0,1fr) auto}.meter-workflow-progress{grid-column:1 / -1;grid-row:2}.meter-lut-calculation-progress{grid-template-columns:minmax(0,1fr) auto}.meter-lut-calculation-bar{grid-column:1 / -1;grid-row:2}}
 .offline-mask-title{font-size:1rem;font-weight:700;margin-bottom:6px}
 .offline-mask-text{font-size:.85rem;line-height:1.45;color:var(--text2)}
 .status-bar{display:flex;align-items:center;justify-content:flex-end;gap:10px;min-width:0;font-size:.8rem;color:var(--text2)}
@@ -13344,6 +13349,11 @@ body.layout-tablet .ui-choice:disabled:hover .ui-choice-description,body.layout-
    </div>
    <div id="meterWorkflowProgressBar" class="meter-workflow-progress"><div id="meterWorkflowProgressFill" class="meter-workflow-progress-fill"></div></div>
    <span id="meterProgressPercent" class="meter-workflow-progress-percent"></span>
+  </div>
+  <div id="meterLutCalculationProgress" class="meter-lut-calculation-progress" style="display:none">
+   <span id="meterLutCalculationLabel" class="meter-lut-calculation-label">3D LUT calculation</span>
+   <div id="meterLutCalculationBar" class="meter-lut-calculation-bar" role="progressbar" aria-valuemin="0"><div id="meterLutCalculationFill" class="meter-lut-calculation-fill"></div></div>
+   <span id="meterLutCalculationCount" class="meter-lut-calculation-count">0 / 0 nodes</span>
   </div>
 
   <div id="meterGreyProfileModal" style="display:none;position:fixed;inset:0;background:rgba(0,0,0,.7);z-index:10000;align-items:center;justify-content:center;padding:18px;box-sizing:border-box">
@@ -28972,6 +28982,45 @@ function meterSetWorkflowProgress(status,options){
  }
 }
 
+function meterFormatNodeCount(value){
+ return Math.round(value).toLocaleString('en-GB');
+}
+
+function meterUpdateLutCalculationProgress(status){
+ const wrap=document.getElementById('meterLutCalculationProgress');
+ const label=document.getElementById('meterLutCalculationLabel');
+ const count=document.getElementById('meterLutCalculationCount');
+ const bar=document.getElementById('meterLutCalculationBar');
+ const fill=document.getElementById('meterLutCalculationFill');
+ const current=Math.max(0,Number(status&&status.lut_calculation_current_nodes)||0);
+ const total=Math.max(0,Number(status&&status.lut_calculation_total_nodes)||0);
+ const active=!!(status&&status.lut_calculation_active&&String(status.status||'').toLowerCase()==='running'&&total>0);
+ if(!active){
+  meterHideLutCalculationProgress();
+  return;
+ }
+ const safeCurrent=Math.min(current,total);
+ const pct=total>0?Math.max(0,Math.min(100,100*safeCurrent/total)):0;
+ if(wrap) wrap.style.display='grid';
+ if(label) label.textContent=String(status.lut_calculation_stage||'3D LUT calculation');
+ if(count) count.textContent=meterFormatNodeCount(safeCurrent)+' / '+meterFormatNodeCount(total)+' nodes';
+ if(fill) fill.style.width=pct+'%';
+ if(bar){
+  bar.setAttribute('aria-valuemax',String(Math.round(total)));
+  bar.setAttribute('aria-valuenow',String(Math.round(safeCurrent)));
+  bar.setAttribute('aria-valuetext',meterFormatNodeCount(safeCurrent)+' of '+meterFormatNodeCount(total)+' nodes');
+ }
+}
+
+function meterHideLutCalculationProgress(){
+ const wrap=document.getElementById('meterLutCalculationProgress');
+ const fill=document.getElementById('meterLutCalculationFill');
+ const bar=document.getElementById('meterLutCalculationBar');
+ if(wrap) wrap.style.display='none';
+ if(fill) fill.style.width='0%';
+ if(bar){ bar.removeAttribute('aria-valuenow'); bar.removeAttribute('aria-valuetext'); }
+}
+
 function meterClearWorkflowProgress(){
  const pctText=document.getElementById('meterProgressPercent');
  const bar=document.getElementById('meterWorkflowProgressBar');
@@ -28988,6 +29037,7 @@ function meterHideWorkflowProgress(){
  const progress=document.getElementById('meterProgress');
  if(progress) progress.style.display='none';
  meterClearWorkflowProgress();
+ meterHideLutCalculationProgress();
 }
 
 function meterHideProgressIfIdle(){
@@ -30006,6 +30056,7 @@ function meterClearInteractiveSelection(keepLiveReading){
  if(!keepLiveReading){
   document.getElementById('meterLiveReading').style.display='none';
   document.getElementById('meterProgress').style.display='none';
+  meterHideLutCalculationProgress();
  }
  meterUpdateReadButtons();
 }
@@ -33917,6 +33968,11 @@ function meterLutSolveProgressUpdate(status){
  const sz=Number(s.cube_lut_size||s.solve_cube_size||0);
  if(sz===17||sz===33||sz===65) bits.push(sz+'³ export');
  if(s.lattice_nodes!=null) bits.push(s.lattice_nodes+' profile nodes');
+ const nodeCurrent=Math.max(0,Number(s.lut_calculation_current_nodes)||0);
+ const nodeTotal=Math.max(0,Number(s.lut_calculation_total_nodes)||0);
+ const nodeProgress=!!(s.lut_calculation_active&&nodeTotal>0);
+ // Bar tracks the monotonic stage bands; per-stage node counts restart at
+ // zero for each stage, so they feed the detail line only.
  const pct=Number(s.solve_progress_pct);
  if(Number.isFinite(pct)&&pct>=0){
   if(fill){
@@ -33924,6 +33980,7 @@ function meterLutSolveProgressUpdate(status){
    fill.style.width=Math.max(8,Math.min(100,pct))+'%';
   }
   bits.push(Math.round(Math.min(100,pct))+'%');
+  if(nodeProgress) bits.push(meterFormatNodeCount(Math.min(nodeCurrent,nodeTotal))+' / '+meterFormatNodeCount(nodeTotal)+' nodes');
  } else if(fill){
   // Indeterminate shimmer while the worker has no percent yet.
   const cur=parseFloat(fill.style.width)||12;
@@ -33979,12 +34036,12 @@ async function meterLutSolvePoll(){
   }
   return;
  }
- if(s.status==='error'){
+ if(s.status==='error'||s.status==='cancelled'){
   if(meterLutSolvePolling){ clearInterval(meterLutSolvePolling); meterLutSolvePolling=null; }
   meterLutSolvePendingDownload='';
   meterBuild3dLutPending=null;
   meterLutSolveProgressHide();
-  toast(s.message||'LUT solve failed',true);
+  toast(s.message||'LUT solve failed',s.status==='error');
  }
 }
 
@@ -43429,6 +43486,7 @@ function meterLg3dApplyStatus(status){
  const labelText=(status.current_name||status.message||'LG 3D LUT AutoCal')+(summary?' | '+summary:'');
  if(status.status==='running') meterSetWorkflowProgress(status,{workflow:meterFullAutoCalRunning?'full':'3d-lut',label:labelText});
  else meterHideWorkflowProgress();
+ meterUpdateLutCalculationProgress(status);
  if(status.status==='running'){
   meterLg3dAutoCalRunning=true;
   meterActionPending=false;
@@ -51462,6 +51520,7 @@ function meterApplyClearedState(showToastMsg){
  _selectedColorReadingName=null;
  _colorDetailPinned=false;
  document.getElementById('meterProgress').style.display='none';
+ meterHideLutCalculationProgress();
  document.getElementById('meterLiveReading').style.display='none';
  document.getElementById('meterExportRow').style.display='none';
  meterResetLiveReadingDisplay();


### PR DESCRIPTION
## Summary

  This PR substantially hardens the LG AutoCal workflow across picture-mode control, greyscale convergence, 3D LUT
  generation and WebUI behaviour.

  The main goal is to make calibration results honest and dependable: the selected Delta E target is now carried
  through the complete workflow, difficult points receive genuine convergence attempts, bounded misses are reported
  as warnings rather than false successes, and invalid measurements are prevented from contaminating the generated
  calibration.

  ## Key changes

  ### LG picture-mode handling

  - Uses the minimal public WebOS settings request when changing picture mode on supported televisions.
  - Independently reads the selected mode back from the television instead of trusting a successful write response.
  - Reports an explicit error when the television acknowledges a request but remains in the previous mode.
  - Uses strict picture-mode comparison while supporting known legitimate WebOS naming differences, including Dolby
    Vision Cinema Dark and Game Optimiser.

  - Preserves the established bridge workflow for 2021 models that do not expose public picture-mode readback.
  - Retains a Luna fallback when the public WebOS request is rejected because of permissions.
  - Adds extensive regression coverage for SDR, HDR, Dolby Vision and generation-specific behaviour.

  ### CEC and television reachability

  - Treats CEC power information as advisory rather than using it as an AutoCal launch gate.
  - Prevents stale, missing or incorrect CEC information from blocking a reachable WebOS television.
  - Uses the worker’s initial picture-settings request as the actual reachability authority.
  - Applies bounded helper timeouts to read-only picture-setting polls so an unavailable television cannot occupy
    the WebUI worker indefinitely.

  ### Full AutoCal replay protection

  - Prevents a stale browser tab or device from starting the 3D LUT stage more than once for the same Full AutoCal
    run.

  - Verifies completed runs using both live worker state and durable report archives.
  - Rejects replays before they can stop an active meter session or upload another LUT.
  - Retires stale browser workflow state safely without aborting the legitimate active session.
  - Tightens browser-side phase and run-ID validation before advancing between Full AutoCal stages.

  ### 3D LUT calculation progress

  - Adds live node-level progress for export-cube and LG 33³ payload generation.
  - Displays the current stage, completed node count, total nodes and a dedicated progress bar.
  - Reports progress from both serial and parallel LUT generation.
  - Keeps the parent process as the sole writer of public status state, avoiding races between worker processes.
  - Improves cancellation handling by terminating calculation workers, cleaning temporary files and reporting
    cancellation separately from failure.

  - Preserves the existing serial fallback when parallel generation cannot complete successfully.

  ### Delta E target convergence

  - Propagates the operator-selected Delta E target into the specialised HDR, Dolby Vision and SDR DPG solvers.
  - Sends the selected target from every relevant WebUI start and touch-up path.
  - Publishes the resolved target and its source in worker state and diagnostic logs.
  - Removes the default low-IRE target relaxation: shadow points now use the requested target unless an expert
    override is explicitly supplied.

  - Separates a usable white measurement from a genuinely converged white measurement.
  - Prevents small white-channel residuals from ending an above-target solve before several genuine attempts have
    been made.

  - Continues solving when restored coefficients are remeasured and found to be above the requested target.
  - Automatically revisits an unresolved 2.3% SDR shadow anchor after neighbouring dark-detail points have settled.
  - Retains explicit iteration and revert limits so physically difficult points still terminate.
  - Reports exhausted, above-target points as warnings rather than marking them as successfully converged.
  - Allows a usable best-effort curve to remain installed while accurately reporting any remaining misses.

  ### Measurement and upload validation

  - Adds shared AutoCal safety helpers used by both greyscale and 3D LUT workers.
  - Rejects missing, non-numeric, negative or implausibly black readings for non-black patches.
  - Detects collapsed pure-primary ramps, such as a valid 90% blue measurement followed by a black or severely
    reduced 100% blue measurement.

  - Applies the same validation to drift-anchor measurements.
  - Retries rejected profile readings before allowing them into the colour model.
  - Treats a successfully verified final LUT and tone-map recommit as recovery from an earlier re-establishment
    failure.

  - Ensures terminal diagnostics describe what was ultimately installed on the television.

  ### WebUI reliability and performance

  - Persists manually selected target white and black levels through server-backed meter settings.
  - Restores measured/manual target-level choices when settings are loaded.
  - Avoids repainting every AutoCal chart and serialising the complete cache on unchanged status polls.
  - Uses the frame-budgeted greyscale renderer during active calibration.
  - Performs a final synchronous chart render when calibration reaches a terminal state.

  ## Testing and validation

  - Added compile checks covering the LG modules, both AutoCal workers, the daemon helper and shared safety module.
  - Added focused tests for:
      - Delta E target propagation and convergence safeguards.
      - Restored-coefficient verification.
      - Critical-shadow revisits.
      - Invalid profile and primary-ramp measurements.
      - Full AutoCal replay prevention.
      - CEC-independent launch behaviour and bounded helper timeouts.
      - AutoCal chart repaint throttling.
      - LG picture-mode writes, readback and generation-specific behaviour.

  - prove -lr t: 164 tests passed.
  - Picture-mode regression suite: 68 tests passed.
  - Perl syntax checks passed for all changed runtime files.
  - A live Raspberry Pi HDR Cinema Full AutoCal run confirmed that the selected 0.2 Delta E target reached the
    active solver. The workflow completed its greyscale, 3D LUT, tone-map and DPG stages, verified the installed
    payloads, and reported remaining bounded misses as warnings instead of false success.

  ## Commit breakdown

  1. 7b4081e6 — Harden LG AutoCal and picture-mode handling
      - Picture-mode write/readback verification, CEC changes, helper timeouts, replay protection and regression
        infrastructure.

  2. 9d25d946 — Show node progress during 3D LUT generation
      - Node-level LUT progress, parallel-worker reporting, cancellation handling and WebUI progress display.

  3. 74a6ff13 — Harden LG AutoCal target convergence and validation
      - Delta E target propagation, stricter convergence, measurement validation, shadow revisits, settings
        persistence and WebUI repaint optimisation.