### PR TITLE
Accept macos as a companion platform

### DIFF
--- a/usr/share/PGenerator/PGICCProfile.pm
+++ b/usr/share/PGenerator/PGICCProfile.pm
@@ -420,7 +420,7 @@ sub webui_icc_pair_request (@) {
  return '{"status":"error","message":"Pairing request is empty"}' unless(defined($body) && length($body)>0 && length($body)<4096);
  my ($client,$platform,$version)=("","","");
  $client=$1 if($body=~/"client"\s*:\s*"([A-Za-z0-9._-]{1,64})"/);
- $platform=$1 if($body=~/"platform"\s*:\s*"(windows|linux)"/);
+ $platform=$1 if($body=~/"platform"\s*:\s*"(windows|linux|macos)"/);
  $version=$1 if($body=~/"version"\s*:\s*"([0-9.]{1,16})"/);
  return '{"status":"error","message":"Invalid pairing request"}' if($client eq "" || $platform eq "" || $version eq "");
  $ip="" unless(defined($ip) && $ip=~/^[0-9A-Fa-f:.]{1,45}$/);
@@ -638,7 +638,7 @@ sub webui_icc_companion_poll (@) {
  # so the UI needs this to say what is unavailable rather than showing the
  # missing values as a fault.
  my $platform=&webui_icc_companion_query_value($query,"platform")||"";
- $platform="" unless($platform=~/\A(?:windows|linux)\z/);
+ $platform="" unless($platform=~/\A(?:windows|linux|macos)\z/);
  my $swapchain_cs=&webui_icc_companion_query_value($query,"swapchain_cs")||"unknown";
  my $presentation=&webui_icc_companion_query_value($query,"presentation")||"unknown";
  # The Companion's own reason a requested transform is not running.


### PR DESCRIPTION
Closes #37.

`PGICCProfile.pm` validates the companion's reported platform against `(windows|linux)` in the pair-request handler at line 423 and again in the poll handler at line 641. The macOS Companion reports `macos`, so pairing is rejected outright with "Invalid pairing request".

Both regexes widen to `(windows|linux|macos)`.

## Verification

Against a unit reporting `shipped_version 1.4.14.1`, POSTing to `/api/icc/companion/pair-request` directly so the result is the server's rather than the Companion's:

```
{"client":"probe","platform":"macos","version":"1.4.20"}
  -> {"status":"error","message":"Invalid pairing request"}

{"client":"probe","platform":"windows","version":"1.4.20"}
  -> {"status":"pending","request":"e7b8b2b5…","code":"276502","expires_in":180}
```

Same request, one field different.

To be exact about what has and hasn't been tested: that is the **unmatched-platform behaviour measured on hardware**, which is what establishes the bug. The patched module has had `perl -c` run against it and nothing more — we don't have a unit we can safely reflash to confirm the post-fix pairing end to end. Worth someone running it on a bench unit before merging, since it's a two-line change to the pairing path.

The two are not equally severe. Line 423 is the hard failure: an unmatched platform leaves `$platform` empty and line 425 rejects the request outright. Line 641 only blanks the value that reaches the status JSON at line 672, so pairing survives but the WebUI cannot say what the Companion is — which is exactly what the comment above it says the field is for.

## Deliberately not included

The WebUI has a few Linux/Windows assumptions that a `macos` case would want — the download asset map, the OS sniff, and the "Compositor profile handling (KWin)" label, which is Linux-specific. We carry a patch for those but left it out here so this stays reviewable at a glance. Say the word and I'll add it, either to this branch or a follow-up.
